### PR TITLE
Dev progess/qte auto mix after add

### DIFF
--- a/Assets/_Core/Prefabs/Item/Finaux/PB_Cauldrons_001.prefab
+++ b/Assets/_Core/Prefabs/Item/Finaux/PB_Cauldrons_001.prefab
@@ -154,7 +154,6 @@ MonoBehaviour:
   _scriptableBoolEvent: {fileID: 11400000, guid: e5cd9f6ebb003824288b4389a9d1261e, type: 2}
   _imageQTE: {fileID: 8589104317660538512}
   _imageProgressBar: {fileID: 3427428850582740811}
-  _interactUI: {fileID: 0}
 --- !u!114 &6692937067275826550
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,8 +166,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ea8b7bc593b245641b2bc08c2297e26d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _interactUI: {fileID: 0}
-  _bubbleVFX: {fileID: 0}
   _allRecipes:
   - {fileID: 11400000, guid: e8a106a6a8d55d84fa46de7214e9e10a, type: 2}
   - {fileID: 11400000, guid: 2a77a3a0aaafda243825891c4a91caa5, type: 2}
@@ -181,6 +178,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6e27954170305fe4ca88477991db0849, type: 2}
   - {fileID: 11400000, guid: 89a5cc1ca70f53249860395a431e6f77, type: 2}
   _currentIngredients: []
+  _potionListData: {fileID: 0}
 --- !u!114 &3245894849006132105
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -15036,7 +15036,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 869431238012741829, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Name
-      value: TimerFront
+      value: progressBarFront
       objectReference: {fileID: 0}
     - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalScale.y
@@ -15100,7 +15100,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1517845104003434308, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Name
-      value: TimerBack
+      value: progressBar
       objectReference: {fileID: 0}
     - target: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalPosition.x
@@ -15154,6 +15154,18 @@ PrefabInstance:
       propertyPath: m_FillOrigin
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2679293524524011747, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2679293524524011747, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2679293524524011747, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -1.29
+      objectReference: {fileID: 0}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _smokeVFX
       value: 
@@ -15166,6 +15178,10 @@ PrefabInstance:
       propertyPath: _burnedVFX
       value: 
       objectReference: {fileID: 574584865}
+    - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: _notStirCooldown
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _fireVFXArray.Array.size
       value: 3
@@ -15185,6 +15201,10 @@ PrefabInstance:
     - target: {fileID: 3427428850582740811, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3427428850582740811, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_FillAmount
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalPosition.z
@@ -16331,12 +16351,16 @@ PrefabInstance:
       value: -0.173
       objectReference: {fileID: 0}
     - target: {fileID: 8218548788836043756, guid: 3d70d69aab85a7b4eadd8c08af44e816, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8218548788836043756, guid: 3d70d69aab85a7b4eadd8c08af44e816, type: 3}
       propertyPath: m_LocalScale.x
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8218548788836043756, guid: 3d70d69aab85a7b4eadd8c08af44e816, type: 3}
       propertyPath: m_LocalScale.y
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8218548788836043756, guid: 3d70d69aab85a7b4eadd8c08af44e816, type: 3}
       propertyPath: m_AnchoredPosition.x

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -471,7 +471,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1685075991}
+    m_TransformParent: {fileID: 950987542}
     m_Modifications:
     - target: {fileID: 634868878547612823, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: looping
@@ -487,11 +487,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29
+      value: 0.28999996
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.z
@@ -921,6 +921,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 784807730}
     - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: _potionListData
+      value: 
+      objectReference: {fileID: 11400000, guid: 66dc7d06323c3ff4c8ba46dba43958bd, type: 2}
+    - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _allRecipes.Array.size
       value: 3
       objectReference: {fileID: 0}
@@ -956,17 +960,11 @@ PrefabInstance:
       addedObject: {fileID: 657664016}
     - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: 1
-      addedObject: {fileID: 296057230}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 2
-      addedObject: {fileID: 708228103}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 2106178516}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      addedObject: {fileID: 1886642911}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 784807729}
-    m_AddedComponents: []
+      addedObject: {fileID: 840341585}
   m_SourcePrefab: {fileID: 100100000, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
 --- !u!4 &114074175 stripped
 Transform:
@@ -1326,7 +1324,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1685075991}
+    m_TransformParent: {fileID: 950987542}
     m_Modifications:
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1338,7 +1336,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.198
+      value: -0.19799995
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalRotation.w
@@ -2193,7 +2191,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 114074175}
+    m_TransformParent: {fileID: 1886642911}
     m_Modifications:
     - target: {fileID: 1796299149479753501, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: playOnAwake
@@ -2205,15 +2203,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.091
+      value: -0.0910002
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.332
+      value: -0.33200002
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.211
+      value: 0.21099973
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalRotation.w
@@ -2319,19 +2317,19 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 415029659}
+    m_TransformParent: {fileID: 956133614}
     m_Modifications:
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.067
+      value: -0.06699991
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.212
+      value: 0.21200001
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.277
+      value: -0.2770002
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3587,17 +3585,11 @@ PrefabInstance:
       addedObject: {fileID: 958651775}
     - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: 1
-      addedObject: {fileID: 1892623083}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 2
-      addedObject: {fileID: 334606329}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 690143809}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      addedObject: {fileID: 956133614}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 917227032}
-    m_AddedComponents: []
+      addedObject: {fileID: 2026038723}
   m_SourcePrefab: {fileID: 100100000, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
 --- !u!4 &415029659 stripped
 Transform:
@@ -4697,6 +4689,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f9447f7c316a2a645b1955952b5b17f5, type: 3}
+--- !u!1 &540568288 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 967855118879278569}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &547461420
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6493,7 +6490,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 415029659}
+    m_TransformParent: {fileID: 956133614}
     m_Modifications:
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6505,7 +6502,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.198
+      value: -0.1980002
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalRotation.w
@@ -6650,19 +6647,19 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 114074175}
+    m_TransformParent: {fileID: 1886642911}
     m_Modifications:
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.067
+      value: -0.06700003
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.212
+      value: 0.21200001
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.277
+      value: -0.2770002
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -7287,7 +7284,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 114074175}
+    m_TransformParent: {fileID: 1886642911}
     m_Modifications:
     - target: {fileID: 634868878547612823, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: looping
@@ -7303,15 +7300,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29
+      value: 0.28999996
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.25
+      value: -0.24999976
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalRotation.w
@@ -7541,6 +7538,30 @@ ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 5285080745272661027, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
   m_PrefabInstance: {fileID: 1681433011}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &840341580 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 114074174}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &840341585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840341580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88d8b041580134444a4eb216ad880ac6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _bubbleVFX: {fileID: 784807730}
+  _smokeVFX: {fileID: 708228104}
+  _burnedVFX: {fileID: 2106178517}
+  _fireVFXArray:
+  - {fileID: 296057233}
+  - {fileID: 296057232}
+  - {fileID: 296057231}
 --- !u!1001 &847042680
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7958,7 +7979,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 415029659}
+    m_TransformParent: {fileID: 956133614}
     m_Modifications:
     - target: {fileID: 634868878547612823, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: looping
@@ -7974,15 +7995,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.29
+      value: 0.28999996
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.25
+      value: -0.24999976
       objectReference: {fileID: 0}
     - target: {fileID: 2109172969400483638, guid: 6b3e1b6bd10a32e4fb1357aefe4149b2, type: 3}
       propertyPath: m_LocalRotation.w
@@ -8100,6 +8121,76 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: da4a8b4edc96ad74cb6b98fdbd72f97c, type: 3}
+--- !u!1 &950987541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 950987542}
+  m_Layer: 7
+  m_Name: VFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &950987542
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 950987541}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 906189990}
+  - {fileID: 1084976874}
+  - {fileID: 574584863}
+  - {fileID: 1984760749}
+  m_Father: {fileID: 1685075991}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &956133613
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 956133614}
+  m_Layer: 7
+  m_Name: VFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &956133614
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 956133613}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 917227032}
+  - {fileID: 334606329}
+  - {fileID: 690143809}
+  - {fileID: 1892623083}
+  m_Father: {fileID: 415029659}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &958651774
 GameObject:
   m_ObjectHideFlags: 0
@@ -11295,19 +11386,19 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1685075991}
+    m_TransformParent: {fileID: 950987542}
     m_Modifications:
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.067
+      value: -0.06699991
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.212
+      value: 0.21200001
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.277
+      value: -0.27699995
       objectReference: {fileID: 0}
     - target: {fileID: 2163895362221356443, guid: a08cfbc646ab4df4bb828c98044805d1, type: 3}
       propertyPath: m_LocalRotation.w
@@ -11968,7 +12059,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1685075991}
+    m_TransformParent: {fileID: 950987542}
     m_Modifications:
     - target: {fileID: 1796299149479753501, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: playOnAwake
@@ -11980,15 +12071,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.091
+      value: -0.09100008
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.332
+      value: -0.33200002
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.211
+      value: 0.21099997
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalRotation.w
@@ -12036,6 +12127,25 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
   m_PrefabInstance: {fileID: 967855118879278569}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1685075996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540568288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88d8b041580134444a4eb216ad880ac6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _bubbleVFX: {fileID: 1482530589}
+  _smokeVFX: {fileID: 1084976876}
+  _burnedVFX: {fileID: 574584865}
+  _fireVFXArray:
+  - {fileID: 1021961989}
+  - {fileID: 1161223701}
+  - {fileID: 836556005}
 --- !u!1001 &1706153518
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -12816,13 +12926,48 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5914402653117790097, guid: c055257eee6a88a4085c590cd76b01c9, type: 3}
   m_PrefabInstance: {fileID: 61450140}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1886642910
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1886642911}
+  m_Layer: 7
+  m_Name: VFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1886642911
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886642910}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 784807729}
+  - {fileID: 708228103}
+  - {fileID: 2106178516}
+  - {fileID: 296057230}
+  m_Father: {fileID: 114074175}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1892623082
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 415029659}
+    m_TransformParent: {fileID: 956133614}
     m_Modifications:
     - target: {fileID: 1796299149479753501, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: playOnAwake
@@ -12834,15 +12979,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.091
+      value: -0.09100008
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.332
+      value: -0.33200002
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.211
+      value: 0.21099973
       objectReference: {fileID: 0}
     - target: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
       propertyPath: m_LocalRotation.w
@@ -14207,6 +14352,30 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9174660943231322965, guid: afe8effb26738704e9ecc5f22e745ec1, type: 3}
   m_PrefabInstance: {fileID: 479010450}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2026038718 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 415029658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2026038723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2026038718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88d8b041580134444a4eb216ad880ac6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _bubbleVFX: {fileID: 917227033}
+  _smokeVFX: {fileID: 334606330}
+  _burnedVFX: {fileID: 690143810}
+  _fireVFXArray:
+  - {fileID: 1892623086}
+  - {fileID: 1892623085}
+  - {fileID: 1892623084}
 --- !u!1001 &2029365755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14906,7 +15075,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 114074175}
+    m_TransformParent: {fileID: 1886642911}
     m_Modifications:
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.x
@@ -14918,7 +15087,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.198
+      value: -0.1980002
       objectReference: {fileID: 0}
     - target: {fileID: 1108041775573133330, guid: f6981e386e9621846949b4c20882c197, type: 3}
       propertyPath: m_LocalRotation.w
@@ -15298,17 +15467,11 @@ PrefabInstance:
       addedObject: {fileID: 2035412666}
     - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: 1
-      addedObject: {fileID: 1984760749}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 2
-      addedObject: {fileID: 1084976874}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 574584863}
-    - targetCorrespondingSourceObject: {fileID: 1760985450580553861, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      addedObject: {fileID: 950987542}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 906189990}
-    m_AddedComponents: []
+      addedObject: {fileID: 1685075996}
   m_SourcePrefab: {fileID: 100100000, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
 --- !u!1001 &2668268833387748728
 PrefabInstance:

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -737,8 +737,32 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.063
+      value: -0.1789999
       objectReference: {fileID: 0}
     - target: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Name
@@ -882,19 +906,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.96469736
+      value: -0.46
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.00000014901161
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -1
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.048082788
+      value: 0.9
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -3406,8 +3430,32 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.063
+      value: -0.1789999
       objectReference: {fileID: 0}
     - target: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Name
@@ -3547,19 +3595,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.96469736
+      value: -0.46
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.00000014901161
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -1
+      value: -0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.048082788
+      value: 0.89
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -15592,8 +15640,28 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.063
+      value: -0.179
+      objectReference: {fileID: 0}
+    - target: {fileID: 1045760451643515370, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180
       objectReference: {fileID: 0}
     - target: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Name
@@ -15729,7 +15797,7 @@ PrefabInstance:
       objectReference: {fileID: 574584865}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _itemCooldown
-      value: 10
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _notStirCooldown
@@ -15761,19 +15829,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.96469736
+      value: -0.46
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.00000014901161
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -1
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.048082788
+      value: 0.97
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -15781,7 +15857,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5647863267903835745, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -180
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 6410677651445800093, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Enabled

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -930,7 +930,7 @@ PrefabInstance:
       objectReference: {fileID: 11400000, guid: 66dc7d06323c3ff4c8ba46dba43958bd, type: 2}
     - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _allRecipes.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: '_allRecipes.Array.data[0]'
@@ -944,6 +944,10 @@ PrefabInstance:
       propertyPath: '_allRecipes.Array.data[2]'
       value: 
       objectReference: {fileID: 11400000, guid: ba6bfc1161455a649a1424d7be7c50da, type: 2}
+    - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: '_allRecipes.Array.data[3]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 8e29245140ea56b4e8f59f6c79996861, type: 2}
     - target: {fileID: 8589104317660538512, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -3586,8 +3590,12 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 917227033}
     - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: _potionListData
+      value: 
+      objectReference: {fileID: 11400000, guid: 66dc7d06323c3ff4c8ba46dba43958bd, type: 2}
+    - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _allRecipes.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: '_allRecipes.Array.data[0]'
@@ -3601,6 +3609,10 @@ PrefabInstance:
       propertyPath: '_allRecipes.Array.data[2]'
       value: 
       objectReference: {fileID: 11400000, guid: ba6bfc1161455a649a1424d7be7c50da, type: 2}
+    - target: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: '_allRecipes.Array.data[3]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 8e29245140ea56b4e8f59f6c79996861, type: 2}
     - target: {fileID: 8589104317660538512, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -7632,6 +7644,17 @@ MonoBehaviour:
   - {fileID: 296057233}
   - {fileID: 296057232}
   - {fileID: 296057231}
+--- !u!114 &840341587 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 114074174}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840341580}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea8b7bc593b245641b2bc08c2297e26d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &847042680
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7708,6 +7731,7 @@ GameObject:
   m_Component:
   - component: {fileID: 867545600}
   - component: {fileID: 867545599}
+  - component: {fileID: 867545601}
   m_Layer: 0
   m_Name: Cinemachine Cauldron_002
   m_TagString: Untagged
@@ -7773,6 +7797,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 730403641}
   m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
+--- !u!114 &867545601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 867545598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bba27206841f44438773a97cb3bc996, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _CauldronRecipeChecker: {fileID: 2026038725}
+  _baseCameraController: {fileID: 273686542}
+  _basePriority: 12
+  _stirPriority: 10
 --- !u!1001 &868215298
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13313,6 +13353,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1918393679}
   - component: {fileID: 1918393678}
+  - component: {fileID: 1918393680}
   m_Layer: 0
   m_Name: Cinemachine Cauldron_003
   m_TagString: Untagged
@@ -13378,6 +13419,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 730403641}
   m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
+--- !u!114 &1918393680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918393677}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bba27206841f44438773a97cb3bc996, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _CauldronRecipeChecker: {fileID: 840341587}
+  _baseCameraController: {fileID: 273686542}
+  _basePriority: 12
+  _stirPriority: 11
 --- !u!1001 &1921106688
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14406,6 +14463,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1976132362}
   - component: {fileID: 1976132361}
+  - component: {fileID: 1976132363}
   m_Layer: 0
   m_Name: Cinemachine Cauldron_001
   m_TagString: Untagged
@@ -14471,6 +14529,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 730403641}
   m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
+--- !u!114 &1976132363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976132360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bba27206841f44438773a97cb3bc996, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _CauldronRecipeChecker: {fileID: 967855118879278572}
+  _baseCameraController: {fileID: 273686542}
+  _basePriority: 12
+  _stirPriority: 9
 --- !u!4 &1984760749 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
@@ -14671,6 +14745,17 @@ MonoBehaviour:
   - {fileID: 1892623086}
   - {fileID: 1892623085}
   - {fileID: 1892623084}
+--- !u!114 &2026038725 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 415029658}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2026038718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea8b7bc593b245641b2bc08c2297e26d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2029365755
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15768,6 +15853,17 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1685075996}
   m_SourcePrefab: {fileID: 100100000, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+--- !u!114 &967855118879278572 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6692937067275826550, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+  m_PrefabInstance: {fileID: 967855118879278569}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 540568288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ea8b7bc593b245641b2bc08c2297e26d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2668268833387748728
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -15179,6 +15179,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 574584865}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: _itemCooldown
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _notStirCooldown
       value: 10
       objectReference: {fileID: 0}

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -744,6 +744,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: PB_Cauldrons_003
       objectReference: {fileID: 0}
+    - target: {fileID: 1111919283123744649, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1229038839658155756, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _qTE
       value: 
@@ -1825,7 +1829,7 @@ GameObject:
   - component: {fileID: 273686543}
   - component: {fileID: 273686542}
   m_Layer: 0
-  m_Name: Cinemachine
+  m_Name: Main Cinemachine
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1845,7 +1849,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Priority:
     Enabled: 1
-    m_Value: 11
+    m_Value: 12
   OutputChannel: 1
   StandbyUpdate: 1
   m_StreamingVersion: 20241001
@@ -2799,6 +2803,38 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: da4a8b4edc96ad74cb6b98fdbd72f97c, type: 3}
+--- !u!1 &377090151
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 377090152}
+  m_Layer: 0
+  m_Name: Cameras Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &377090152
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 377090151}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.34605244, y: 4.608653, z: -11.033565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 730403641}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &380831304
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4798,7 +4834,7 @@ Transform:
   m_GameObject: {fileID: 575032911}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.7071068, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.32191133, y: 1.5129627, z: 0.62724304}
+  m_LocalPosition: {x: 0.322, y: 1.5129627, z: 0.673}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6340,7 +6376,7 @@ Transform:
   m_GameObject: {fileID: 657664015}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.00000020861626}
-  m_LocalPosition: {x: -0.033, y: 0.304, z: -0.231}
+  m_LocalPosition: {x: -0.033, y: 0.304, z: -0.134}
   m_LocalScale: {x: 0.056, y: 1.8666668, z: 0.056}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -6793,6 +6829,40 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b83f7e9dd227b284db6032b4086fb5ef, type: 3}
+--- !u!1 &730403640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 730403641}
+  m_Layer: 0
+  m_Name: Cameras Cauldrons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &730403641
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 730403640}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1976132362}
+  - {fileID: 867545600}
+  - {fileID: 1918393679}
+  m_Father: {fileID: 377090152}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &730431778
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7628,6 +7698,81 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1000082274375167609, guid: b336cbb3fe5c14c44b7885cad18d684f, type: 3}
   m_PrefabInstance: {fileID: 525158201}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &867545598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 867545600}
+  - component: {fileID: 867545599}
+  m_Layer: 0
+  m_Name: Cinemachine Cauldron_002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &867545599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 867545598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 1
+    m_Value: 10
+  OutputChannel: 1
+  StandbyUpdate: 1
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 55
+    OrthographicSize: 5
+    NearClipPlane: 0.1
+    FarClipPlane: 50.101
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!4 &867545600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 867545598}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.28099987, y: -0.64887524, z: 0.28099996, w: 0.6488752}
+  m_LocalPosition: {x: 1.2439476, y: -2.108653, z: 10.663565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 730403641}
+  m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
 --- !u!1001 &868215298
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13158,6 +13303,81 @@ Transform:
   - {fileID: 451940185}
   m_Father: {fileID: 1778505042}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1918393677
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1918393679}
+  - component: {fileID: 1918393678}
+  m_Layer: 0
+  m_Name: Cinemachine Cauldron_003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1918393678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918393677}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 1
+    m_Value: 11
+  OutputChannel: 1
+  StandbyUpdate: 1
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 55
+    OrthographicSize: 5
+    NearClipPlane: 0.1
+    FarClipPlane: 50.101
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!4 &1918393679
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918393677}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.28099987, y: -0.64887524, z: 0.28099996, w: 0.6488752}
+  m_LocalPosition: {x: 3.1439476, y: -2.108653, z: 10.663565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 730403641}
+  m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
 --- !u!1001 &1921106688
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14176,6 +14396,81 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2eb99bce70648d8479330b26e604f591, type: 3}
+--- !u!1 &1976132360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1976132362}
+  - component: {fileID: 1976132361}
+  m_Layer: 0
+  m_Name: Cinemachine Cauldron_001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1976132361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976132360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Priority:
+    Enabled: 1
+    m_Value: 9
+  OutputChannel: 1
+  StandbyUpdate: 1
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 55
+    OrthographicSize: 5
+    NearClipPlane: 0.1
+    FarClipPlane: 50.101
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!4 &1976132362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1976132360}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.28099987, y: -0.64887524, z: 0.28099996, w: 0.6488752}
+  m_LocalPosition: {x: -0.8660524, y: -2.108653, z: 10.663565}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 730403641}
+  m_LocalEulerAnglesHint: {x: 46.831, y: -90, z: 0}
 --- !u!4 &1984760749 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4927425342343652053, guid: d2e8a8986bbac4447875e95039ef9a07, type: 3}
@@ -16875,8 +17170,9 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1077733916}
-  - {fileID: 273686543}
   - {fileID: 1945221585}
+  - {fileID: 273686543}
+  - {fileID: 377090152}
   - {fileID: 1286800188}
   - {fileID: 612105783}
   - {fileID: 1778505042}

--- a/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Labo.unity
@@ -15729,7 +15729,7 @@ PrefabInstance:
       objectReference: {fileID: 574584865}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _itemCooldown
-      value: 40
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3245894849006132105, guid: fa6c2466c26059c469fb00fcf6f28662, type: 3}
       propertyPath: _notStirCooldown

--- a/Assets/_Core/Scripts/Camera/StirCameraTransition.cs
+++ b/Assets/_Core/Scripts/Camera/StirCameraTransition.cs
@@ -1,0 +1,54 @@
+using MoonlitMixes.CookingMachine;
+using MoonlitMixes.Potion;
+using Unity.Cinemachine;
+using UnityEngine;
+
+namespace MoonlitMixes.Camera.Event
+{
+    public class StirCameraTransition : MonoBehaviour
+    {
+        [Header("Cauldron Reference")]
+        [SerializeField] private CauldronRecipeChecker _CauldronRecipeChecker;
+
+        [Header("Camera Settings")]
+        [SerializeField] private CinemachineCamera _baseCameraController;
+
+        [SerializeField] private int _basePriority = 10;
+        [SerializeField] private int _stirPriority = 11;
+
+        private CinemachineCamera _stirCamera;
+
+        private void Awake()
+        {
+            _stirCamera = GetComponent<CinemachineCamera>();
+
+            if (_CauldronRecipeChecker == null || _stirCamera == null || _baseCameraController == null)
+            {
+                Debug.LogError("Missing reference in StirCameraTransition.");
+                enabled = false;
+                return;
+            }
+
+            _CauldronRecipeChecker.OnStirStarted += HandleStirStart;
+            _CauldronRecipeChecker.OnStirEnded += HandleStirEnd;
+        }
+
+        private void HandleStirStart()
+        {
+            _baseCameraController.Priority = _stirPriority;
+            _stirCamera.Priority = _basePriority;
+        }
+
+        private void HandleStirEnd()
+        {
+            _baseCameraController.Priority = _basePriority;
+            _stirCamera.Priority = _stirPriority;
+        }
+
+        private void OnDestroy()
+        {
+            _CauldronRecipeChecker.OnStirStarted -= HandleStirStart;
+            _CauldronRecipeChecker.OnStirEnded -= HandleStirEnd;
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Camera/StirCameraTransition.cs
+++ b/Assets/_Core/Scripts/Camera/StirCameraTransition.cs
@@ -8,7 +8,7 @@ namespace MoonlitMixes.Camera.Event
     public class StirCameraTransition : MonoBehaviour
     {
         [Header("Cauldron Reference")]
-        [SerializeField] private CauldronRecipeChecker _CauldronRecipeChecker;
+        [SerializeField] private CauldronRecipeChecker _cauldronRecipeChecker;
 
         [Header("Camera Settings")]
         [SerializeField] private CinemachineCamera _baseCameraController;
@@ -22,15 +22,15 @@ namespace MoonlitMixes.Camera.Event
         {
             _stirCamera = GetComponent<CinemachineCamera>();
 
-            if (_CauldronRecipeChecker == null || _stirCamera == null || _baseCameraController == null)
+            if (_cauldronRecipeChecker == null || _stirCamera == null || _baseCameraController == null)
             {
                 Debug.LogError("Missing reference in StirCameraTransition.");
                 enabled = false;
                 return;
             }
 
-            _CauldronRecipeChecker.OnStirStarted += HandleStirStart;
-            _CauldronRecipeChecker.OnStirEnded += HandleStirEnd;
+            _cauldronRecipeChecker.OnStirStarted += HandleStirStart;
+            _cauldronRecipeChecker.OnStirEnded += HandleStirEnd;
         }
 
         private void HandleStirStart()
@@ -47,8 +47,8 @@ namespace MoonlitMixes.Camera.Event
 
         private void OnDestroy()
         {
-            _CauldronRecipeChecker.OnStirStarted -= HandleStirStart;
-            _CauldronRecipeChecker.OnStirEnded -= HandleStirEnd;
+            _cauldronRecipeChecker.OnStirStarted -= HandleStirStart;
+            _cauldronRecipeChecker.OnStirEnded -= HandleStirEnd;
         }
     }
 }

--- a/Assets/_Core/Scripts/Camera/StirCameraTransition.cs.meta
+++ b/Assets/_Core/Scripts/Camera/StirCameraTransition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bba27206841f44438773a97cb3bc996

--- a/Assets/_Core/Scripts/CookingMachine/ACookingMachine.cs
+++ b/Assets/_Core/Scripts/CookingMachine/ACookingMachine.cs
@@ -1,9 +1,9 @@
-using UnityEngine;
-using UnityEngine.UI;
 using MoonlitMixes.Datas;
 using MoonlitMixes.Events;
 using MoonlitMixes.Item;
 using MoonlitMixes.Player;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace MoonlitMixes.CookingMachine
 {
@@ -24,9 +24,9 @@ namespace MoonlitMixes.CookingMachine
         [SerializeField] protected Image _imageProgressBar;
 
         protected PlayerInteraction _playerInteraction;
-        
+
         private ItemData _itemData;
-        
+
         public abstract void ToggleShowInteractivity();
 
         protected void Activate()
@@ -41,7 +41,7 @@ namespace MoonlitMixes.CookingMachine
 
         public virtual void CheckItem(bool boolValue)
         {
-            if(boolValue)
+            if (boolValue)
             {
                 SuccesItem();
             }

--- a/Assets/_Core/Scripts/CookingMachine/ACookingMachine.cs
+++ b/Assets/_Core/Scripts/CookingMachine/ACookingMachine.cs
@@ -9,13 +9,17 @@ namespace MoonlitMixes.CookingMachine
 {
     public abstract class ACookingMachine : MonoBehaviour
     {
+        [Header("Conversion Settings")]
         [SerializeField] protected ItemUsage _transformType;
         public ItemUsage TransformType => _transformType;
-        
+
+        [Header("QTE Settings")]
         [SerializeField] protected ScriptableQTEConfig _scriptableQTEConfig;
         [SerializeField] protected QuickTimeEvent _qTE;
         [SerializeField] protected ScriptableQTEEvent _scriptableQTEEvent;
         [SerializeField] protected ScriptableBoolEvent _scriptableBoolEvent;
+
+        [Header("UI Elements")]
         [SerializeField] protected Image _imageQTE;
         [SerializeField] protected Image _imageProgressBar;
 
@@ -23,7 +27,7 @@ namespace MoonlitMixes.CookingMachine
         
         private ItemData _itemData;
         
-        public abstract void TogleShowInteractivity();
+        public abstract void ToggleShowInteractivity();
 
         protected void Activate()
         {

--- a/Assets/_Core/Scripts/CookingMachine/CauldronMixing.cs
+++ b/Assets/_Core/Scripts/CookingMachine/CauldronMixing.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using MoonlitMixes.Player;
 using MoonlitMixes.Potion;
 
@@ -6,20 +5,17 @@ namespace MoonlitMixes.CookingMachine
 {
     public class CauldronMixing : ACookingMachine
     {
-        [SerializeField] private GameObject _interactUI;
-        
         private CauldronRecipeChecker _cauldronRecipeChecker;
         private bool _isActive = false;
-        
+
         private void Awake()
         {
             _cauldronRecipeChecker = GetComponent<CauldronRecipeChecker>();
         }
-        
-        public override void TogleShowInteractivity()
+
+        public override void ToggleShowInteractivity()
         {
             _isActive = !_isActive;
-            //_interactUI.SetActive(_isActive);
         }
 
         public override void SuccesItem()

--- a/Assets/_Core/Scripts/CookingMachine/CuttingBoard.cs
+++ b/Assets/_Core/Scripts/CookingMachine/CuttingBoard.cs
@@ -8,7 +8,7 @@ namespace MoonlitMixes.CookingMachine
         
         private bool _isActive = false;
         
-        public override void TogleShowInteractivity()
+        public override void ToggleShowInteractivity()
         {
             _isActive = !_isActive;
             //InteractUI.SetActive(_isActive);

--- a/Assets/_Core/Scripts/CookingMachine/KitchenMortar.cs
+++ b/Assets/_Core/Scripts/CookingMachine/KitchenMortar.cs
@@ -8,7 +8,7 @@ namespace MoonlitMixes.CookingMachine
         
         private bool _isActive = false;
         
-        public override void TogleShowInteractivity()
+        public override void ToggleShowInteractivity()
         {
             _isActive = !_isActive;
             //InteractUI.SetActive(_isActive);

--- a/Assets/_Core/Scripts/Item/ItemData.cs
+++ b/Assets/_Core/Scripts/Item/ItemData.cs
@@ -9,11 +9,18 @@ namespace MoonlitMixes.Item
         [SerializeField] private ElementType _elementType;
         [SerializeField, Range(1,4)] private int _rarity;
         [SerializeField] private ItemUsage _itemUsage;
+        [SerializeField] private bool _canBeStirred;
         [SerializeField] private Sprite _sprite;
         [SerializeField] private ItemData _itemToConvert;
         [SerializeField] private string _description;
         [SerializeField] private GameObject _itemPrefab;
         [SerializeField] private ItemUsage _state;
+
+        public bool CanBeStirred
+        {
+            get => _canBeStirred;
+            set => _canBeStirred = value;
+        }
 
         public string ObjectName
         {

--- a/Assets/_Core/Scripts/Item/ItemData.cs
+++ b/Assets/_Core/Scripts/Item/ItemData.cs
@@ -14,7 +14,6 @@ namespace MoonlitMixes.Item
         [SerializeField] private ItemData _itemToConvert;
         [SerializeField] private string _description;
         [SerializeField] private GameObject _itemPrefab;
-        [SerializeField] private ItemUsage _state;
 
         public bool CanBeStirred
         {
@@ -40,11 +39,6 @@ namespace MoonlitMixes.Item
         public ItemUsage Usage
         {
             get => _itemUsage;
-        }
-
-        public ItemUsage State
-        {
-            get => _state;
         }
 
         public Sprite ItemSprite

--- a/Assets/_Core/Scripts/Players/PlayerInteraction.cs
+++ b/Assets/_Core/Scripts/Players/PlayerInteraction.cs
@@ -84,9 +84,9 @@ namespace MoonlitMixes.Player
         {
             if (_currentCauldron != null)
             {
-                _currentCauldron.TogleShowInteractivity();
+                _currentCauldron.ToggleShowInteractivity();
             }
-            newCauldron.TogleShowInteractivity();
+            newCauldron.ToggleShowInteractivity();
             _currentCauldron = newCauldron;
             _currentCookingMachine = null;
         }
@@ -95,18 +95,18 @@ namespace MoonlitMixes.Player
         {
             if (_currentCookingMachine != null)
             {
-                _currentCookingMachine.TogleShowInteractivity();
+                _currentCookingMachine.ToggleShowInteractivity();
             }
-            newCookingMachine.TogleShowInteractivity();
+            newCookingMachine.ToggleShowInteractivity();
             _currentCookingMachine = newCookingMachine;
             _currentCauldron = null;
         }
 
         private void ResetInteractionTargets()
         {
-            if (_currentCauldron != null) _currentCauldron.TogleShowInteractivity();
+            if (_currentCauldron != null) _currentCauldron.ToggleShowInteractivity();
             _currentCauldron = null;
-            if (_currentCookingMachine != null) _currentCookingMachine.TogleShowInteractivity();
+            if (_currentCookingMachine != null) _currentCookingMachine.ToggleShowInteractivity();
             _currentCookingMachine = null;
         }
 

--- a/Assets/_Core/Scripts/Players/PlayerInteraction.cs
+++ b/Assets/_Core/Scripts/Players/PlayerInteraction.cs
@@ -1,11 +1,11 @@
-﻿using UnityEngine;
-using UnityEngine.InputSystem;
+﻿using MoonlitMixes.Animation;
 using MoonlitMixes.CookingMachine;
 using MoonlitMixes.Inputs;
 using MoonlitMixes.Inventory;
 using MoonlitMixes.Item;
 using MoonlitMixes.Potion;
-using MoonlitMixes.Animation;
+using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace MoonlitMixes.Player
 {
@@ -27,7 +27,7 @@ namespace MoonlitMixes.Player
         private Animator _animator;
         private AnimationPotionManager _animationPotionManager;
         private Trashcan _currentTrashcan;
-      
+
 
         private void Awake()
         {
@@ -125,7 +125,7 @@ namespace MoonlitMixes.Player
                             ItemInHand = null;
 
                             _animator.SetTrigger("Put");
-                            
+
                             if (PlayerHoldItem.ItemHold == null)
                             {
                                 _animationPotionManager.QuitInteractWithoutItem();
@@ -172,7 +172,7 @@ namespace MoonlitMixes.Player
                 }
                 else
                 {
-                    if (Physics.Raycast(transform.position, transform.forward  + new Vector3(0, 1, 0), out RaycastHit hit, _interactionDistance, _layerHitable))
+                    if (Physics.Raycast(transform.position, transform.forward + new Vector3(0, 1, 0), out RaycastHit hit, _interactionDistance, _layerHitable))
                     {
                         if (hit.transform.TryGetComponent(out InventoryStoragePotion inventory))
                         {

--- a/Assets/_Core/Scripts/Players/PlayerInteraction.cs
+++ b/Assets/_Core/Scripts/Players/PlayerInteraction.cs
@@ -11,6 +11,10 @@ namespace MoonlitMixes.Player
 {
     public class PlayerInteraction : MonoBehaviour
     {
+        public ItemData ItemInHand { get; set; }
+        public PlayerHoldItem PlayerHoldItem { get; private set; }
+        public PlayerInput CurrentPlayerInput { get; private set; }
+
         [SerializeField] private float _interactionDistance;
         [SerializeField] private LayerMask _layerHitable;
         [SerializeField] private string _actionMapPlayer;
@@ -23,12 +27,11 @@ namespace MoonlitMixes.Player
         private Animator _animator;
         private AnimationPotionManager _animationPotionManager;
         private Trashcan _currentTrashcan;
-
-        public ItemData ItemInHand { get; set; }
-        public PlayerHoldItem PlayerHoldItem { get; private set; }
+      
 
         private void Awake()
         {
+            CurrentPlayerInput = GetComponent<PlayerInput>();
             PlayerHoldItem = GetComponent<PlayerHoldItem>();
             _animator = GetComponent<Animator>();
             _animationPotionManager = GetComponent<AnimationPotionManager>();
@@ -185,12 +188,9 @@ namespace MoonlitMixes.Player
                         }
                         else if (hit.transform.TryGetComponent(out CauldronRecipeChecker cauldron) && cauldron.GetComponent<CauldronTimer>().CanAction)
                         {
-                            if (!cauldron.NeedMix) return;
-                            
                             InputManager.Instance.SwitchActionMap(_actionMapQTE);
-                            cauldron.Mix(this);
-
-                            _animationPotionManager.InteractStir();
+                            //cauldron.Mix(this);
+                            //_animationPotionManager.InteractStir();
                         }
                     }
                 }

--- a/Assets/_Core/Scripts/Players/PlayerInteraction.cs
+++ b/Assets/_Core/Scripts/Players/PlayerInteraction.cs
@@ -186,12 +186,6 @@ namespace MoonlitMixes.Player
                             InputManager.Instance.SwitchActionMap(_actionMapWaitingTable);
                             waitingTable.StartHighlight();
                         }
-                        else if (hit.transform.TryGetComponent(out CauldronRecipeChecker cauldron) && cauldron.GetComponent<CauldronTimer>().CanAction)
-                        {
-                            InputManager.Instance.SwitchActionMap(_actionMapQTE);
-                            //cauldron.Mix(this);
-                            //_animationPotionManager.InteractStir();
-                        }
                     }
                 }
             }

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -6,6 +6,7 @@ using MoonlitMixes.Item;
 using MoonlitMixes.Player;
 using MoonlitMixes.Potion;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace MoonlitMixes.Potion
 {
@@ -29,11 +30,11 @@ namespace MoonlitMixes.Potion
         private bool _needItem = true;
         private ItemData _ingredentToAdd;
         
-        public bool NeedMix
-        {
-            get => _needMix;
-            set => _needMix = value;
-        }
+        //public bool NeedMix
+        //{
+        //    get => _needMix;
+        //    set => _needMix = value;
+        //}
 
         public bool NeedItem
         {
@@ -62,9 +63,7 @@ namespace MoonlitMixes.Potion
         public void AddIngredient(ItemData ingredient)
         {
             if (ingredient == null)
-            {
                 return;
-            }
 
             if (!_currentIngredients.Any())
             {
@@ -74,7 +73,6 @@ namespace MoonlitMixes.Potion
                     {
                         _currentRecipe = recipe;
                         _currentRecipeIndex = 0;
-                        //_cauldronTimer.TimerIsActive = true;
                         break;
                     }
                 }
@@ -93,10 +91,23 @@ namespace MoonlitMixes.Potion
             }
 
             _ingredentToAdd = ingredient;
-            //_cauldronTimer.ResetCooldown();
             TriggerBubbleVFX();
             _needItem = false;
-            _needMix = true;
+
+            // Lancer automatiquement le QTE de mélange
+            if (ingredient.CanBeStirred)
+            {
+                PlayerInteraction playerInteraction = FindFirstObjectByType<PlayerInteraction>();
+
+                // Activer l’action map QTE avant de mélanger
+                PlayerInput input = playerInteraction.GetComponent<PlayerInput>();
+                if (input != null)
+                {
+                    input.SwitchCurrentActionMap("QTE");
+                }
+
+                _cauldronMixing.ConvertItem(playerInteraction);
+            }
         }
 
         private void ValidateIngredientAddition(ItemData ingredient)
@@ -207,9 +218,9 @@ namespace MoonlitMixes.Potion
             ValidateIngredientAddition(_ingredentToAdd);
         }
 
-        public void Mix(PlayerInteraction playerInteraction)
-        {
-            _cauldronMixing.ConvertItem(playerInteraction);
-        }
+        //public void Mix(PlayerInteraction playerInteraction)
+        //{
+        //    _cauldronMixing.ConvertItem(playerInteraction);
+        //}
     }
 }

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -2,6 +2,7 @@ using MoonlitMixes.CookingMachine;
 using MoonlitMixes.Datas;
 using MoonlitMixes.Item;
 using MoonlitMixes.Player;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,6 +13,9 @@ namespace MoonlitMixes.Potion
 {
     public class CauldronRecipeChecker : MonoBehaviour
     {
+        public event Action OnStirStarted;
+        public event Action OnStirEnded;
+
         [Header("Recipe Configuration")]
         [Tooltip("Liste de toutes les recettes possibles à vérifier.")]
         [SerializeField] private List<Recipe> _allRecipes;
@@ -19,7 +23,7 @@ namespace MoonlitMixes.Potion
         [Tooltip("Liste des ingrédients actuellement dans le chaudron.")]
         [SerializeField] private List<ItemData> _currentIngredients = new List<ItemData>();
 
-        [Tooltip("Référence à l'objet Scriptable contenant les potions que le player peut créer.")]
+        [Tooltip("Référence à l'objet Scriptable contenant les potions que le player a.")]
         [SerializeField] private PotionListData _potionListData;
 
         private CauldronTimer _cauldronTimer;
@@ -120,8 +124,12 @@ namespace MoonlitMixes.Potion
         private void StartQTEForStirring(ItemData ingredient)
         {
             QteInProgress = true;
+
+            OnStirStarted?.Invoke();
+            
             PlayerInteraction playerInteraction = FindFirstObjectByType<PlayerInteraction>();
             PlayerInput input = playerInteraction.GetComponent<PlayerInput>();
+
             input?.SwitchCurrentActionMap("QTE");
 
             _cauldronMixing.ConvertItem(playerInteraction);
@@ -240,6 +248,8 @@ namespace MoonlitMixes.Potion
         {
             QteInProgress = false;
             _qteSuccess = state;
+
+            OnStirEnded?.Invoke();
 
             if (state)
             {

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MoonlitMixes.CookingMachine;
 using MoonlitMixes.Datas;
+using MoonlitMixes.Inputs;
 using MoonlitMixes.Item;
 using MoonlitMixes.Player;
 using MoonlitMixes.Potion;
@@ -19,22 +20,15 @@ namespace MoonlitMixes.Potion
         [SerializeField] private List<ItemData> _currentIngredients = new List<ItemData>();
         [SerializeField] private PotionListData _potionListData;
 
-        //private CauldronTimer _cauldronTimer;
+        private CauldronTimer _cauldronTimer;
         private bool _isActive = false;
         private PotionInventory _potionInventory;
         private CauldronMixing _cauldronMixing;
         private bool _qteSuccess;
         private Recipe _currentRecipe;
         private int _currentRecipeIndex;
-        private bool _needMix;
         private bool _needItem = true;
         private ItemData _ingredentToAdd;
-        
-        //public bool NeedMix
-        //{
-        //    get => _needMix;
-        //    set => _needMix = value;
-        //}
 
         public bool NeedItem
         {
@@ -45,12 +39,12 @@ namespace MoonlitMixes.Potion
         private void Awake()
         {
             _cauldronMixing = GetComponent<CauldronMixing>();
-            //_cauldronTimer = GetComponent<CauldronTimer>();
+            _cauldronTimer = GetComponent<CauldronTimer>();
             _potionInventory = FindFirstObjectByType<PotionInventory>();
 
-            //if (_cauldronTimer == null)
+            if (_cauldronTimer == null)
             {
-                //Debug.LogError("CauldronTimer n'est pas attach� au chaudron !");
+                Debug.LogError("CauldronTimer n'est pas attach� au chaudron !");
             }
         }
 
@@ -108,6 +102,10 @@ namespace MoonlitMixes.Potion
 
                 _cauldronMixing.ConvertItem(playerInteraction);
             }
+            else
+            {
+                _cauldronTimer.StartCooldown();
+            }
         }
 
         private void ValidateIngredientAddition(ItemData ingredient)
@@ -118,15 +116,17 @@ namespace MoonlitMixes.Potion
                 return;
             }
 
-            if(_currentRecipe.RequiredIngredients[_currentRecipeIndex] == ingredient)
+            if (_currentRecipe.RequiredIngredients[_currentRecipeIndex] == ingredient)
             {
                 _currentIngredients.Add(ingredient);
-                _needMix = false;
                 _currentRecipeIndex++;
-                //_cauldronTimer.ResetCooldown();
+
+                // Redémarrer le cooldown après mélange réussi
+                _cauldronTimer.ResetCooldown();
+                _cauldronTimer.TimerIsActive = true;
+
                 CheckRecipeCompletion();
             }
-        
         }
 
         private void CheckRecipeCompletion()
@@ -158,7 +158,7 @@ namespace MoonlitMixes.Potion
         {
             _needItem = true;
             _currentRecipe = null;
-            //_cauldronTimer.StopCooldown();
+            _cauldronTimer.StopCooldown();
 
             _potionListData.PotionResults.Add(recipe.Potion);
 
@@ -170,7 +170,7 @@ namespace MoonlitMixes.Potion
         {
             _needItem = true;
             _currentRecipe = null;
-            //_cauldronTimer.StopCooldown();
+            _cauldronTimer.StopCooldown();
 
             _cauldronMixing.DesactiveQTE();
             
@@ -217,10 +217,5 @@ namespace MoonlitMixes.Potion
             _qteSuccess = state;
             ValidateIngredientAddition(_ingredentToAdd);
         }
-
-        //public void Mix(PlayerInteraction playerInteraction)
-        //{
-        //    _cauldronMixing.ConvertItem(playerInteraction);
-        //}
     }
 }

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using MoonlitMixes.CookingMachine;
@@ -25,6 +26,7 @@ namespace MoonlitMixes.Potion
         private PotionInventory _potionInventory;
         private CauldronMixing _cauldronMixing;
         private bool _qteSuccess;
+        public bool _qteInProgress = false;
         private Recipe _currentRecipe;
         private int _currentRecipeIndex;
         private bool _needItem = true;
@@ -44,7 +46,7 @@ namespace MoonlitMixes.Potion
 
             if (_cauldronTimer == null)
             {
-                Debug.LogError("CauldronTimer n'est pas attach� au chaudron !");
+                Debug.LogError("CauldronTimer n'est pas attaché au chaudron !");
             }
         }
 
@@ -73,6 +75,7 @@ namespace MoonlitMixes.Potion
 
                 if (_currentRecipe == null)
                 {
+                    Debug.Log("Recipe is null");
                     TriggerBurnPot();
                     return;
                 }
@@ -88,12 +91,11 @@ namespace MoonlitMixes.Potion
             TriggerBubbleVFX();
             _needItem = false;
 
-            // Lancer automatiquement le QTE de mélange
             if (ingredient.CanBeStirred)
             {
+                _qteInProgress = true;
                 PlayerInteraction playerInteraction = FindFirstObjectByType<PlayerInteraction>();
 
-                // Activer l’action map QTE avant de mélanger
                 PlayerInput input = playerInteraction.GetComponent<PlayerInput>();
                 if (input != null)
                 {
@@ -104,14 +106,35 @@ namespace MoonlitMixes.Potion
             }
             else
             {
-                _cauldronTimer.StartCooldown();
+                StartCoroutine(HandleIngredientWithoutStir(ingredient));
             }
         }
 
-        private void ValidateIngredientAddition(ItemData ingredient)
+        private IEnumerator HandleIngredientWithoutStir(ItemData ingredient)
         {
-            if (!_qteSuccess)
+            _cauldronTimer.PotionSuccessExpected = true;
+
+            Recipe localRecipe = _currentRecipe;
+
+            _cauldronTimer.StartCooldown();
+            Debug.Log("StartCooldown");
+
+            yield return new WaitForSeconds(_cauldronTimer.RemainingTime);
+
+            if (_currentRecipe != localRecipe)
             {
+                Debug.LogWarning("Recette modifiée pendant le cooldown.");
+                yield break;
+            }
+
+            ValidateIngredientWithoutQTE(ingredient);
+        }
+
+        private void ValidateIngredientWithoutQTE(ItemData ingredient)
+        {
+            if (_currentRecipe == null)
+            {
+                Debug.LogWarning("ValidateIngredientAddition appelé sans recette active !");
                 HandleFailedPotion();
                 return;
             }
@@ -121,11 +144,50 @@ namespace MoonlitMixes.Potion
                 _currentIngredients.Add(ingredient);
                 _currentRecipeIndex++;
 
-                // Redémarrer le cooldown après mélange réussi
                 _cauldronTimer.ResetCooldown();
                 _cauldronTimer.TimerIsActive = true;
+                Debug.Log("Success without QTE");
 
                 CheckRecipeCompletion();
+            }
+            else
+            {
+                Debug.Log("Failed without QTE");
+                HandleFailedPotion();
+            }
+        }
+
+        private void ValidateIngredientAddition(ItemData ingredient)
+        {
+            if (_currentRecipe == null)
+            {
+                Debug.LogWarning("ValidateIngredientAddition appelé sans recette active !");
+                HandleFailedPotion();
+                return;
+            }
+
+            if (!_qteSuccess)
+            {
+                Debug.Log("Failed QTE");
+                HandleFailedPotion();
+                return;
+            }
+
+            if (_currentRecipe.RequiredIngredients[_currentRecipeIndex] == ingredient)
+            {
+                _currentIngredients.Add(ingredient);
+                _currentRecipeIndex++;
+
+                _cauldronTimer.ResetCooldown();
+                _cauldronTimer.TimerIsActive = true;
+                Debug.Log("Success with QTE");
+
+                CheckRecipeCompletion();
+            }
+            else
+            {
+                Debug.Log("Failed QTE logic");
+                HandleFailedPotion();
             }
         }
 
@@ -133,8 +195,8 @@ namespace MoonlitMixes.Potion
         {
             if (IsRecipeComplete(_currentRecipe))
             {
+                Debug.Log("Succes");
                 HandleSuccessfulPotion(_currentRecipe);
-                return;
             }
             else
             {
@@ -144,14 +206,7 @@ namespace MoonlitMixes.Potion
 
         private bool IsRecipeComplete(Recipe recipe)
         {
-            if(recipe.RequiredIngredients.Count == _currentRecipeIndex)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return recipe.RequiredIngredients.Count == _currentRecipeIndex;
         }
 
         private void HandleSuccessfulPotion(Recipe recipe)
@@ -173,7 +228,7 @@ namespace MoonlitMixes.Potion
             _cauldronTimer.StopCooldown();
 
             _cauldronMixing.DesactiveQTE();
-            
+
             _currentIngredients.Clear();
             _ingredentToAdd = null;
         }
@@ -214,8 +269,19 @@ namespace MoonlitMixes.Potion
 
         public void CheckQTE(bool state)
         {
+            _qteInProgress = false;
+
             _qteSuccess = state;
-            ValidateIngredientAddition(_ingredentToAdd);
+
+            if (state)
+            {
+                ValidateIngredientAddition(_ingredentToAdd);
+            }
+            else
+            {
+                Debug.Log("Failed QTE");
+                HandleFailedPotion();
+            }
         }
     }
 }

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -18,7 +18,7 @@ namespace MoonlitMixes.Potion
         [SerializeField] private List<ItemData> _currentIngredients = new List<ItemData>();
         [SerializeField] private PotionListData _potionListData;
 
-        private CauldronTimer _cauldronTimer;
+        //private CauldronTimer _cauldronTimer;
         private bool _isActive = false;
         private PotionInventory _potionInventory;
         private CauldronMixing _cauldronMixing;
@@ -44,12 +44,12 @@ namespace MoonlitMixes.Potion
         private void Awake()
         {
             _cauldronMixing = GetComponent<CauldronMixing>();
-            _cauldronTimer = GetComponent<CauldronTimer>();
+            //_cauldronTimer = GetComponent<CauldronTimer>();
             _potionInventory = FindFirstObjectByType<PotionInventory>();
 
-            if (_cauldronTimer == null)
+            //if (_cauldronTimer == null)
             {
-                Debug.LogError("CauldronTimer n'est pas attach� au chaudron !");
+                //Debug.LogError("CauldronTimer n'est pas attach� au chaudron !");
             }
         }
 
@@ -74,7 +74,7 @@ namespace MoonlitMixes.Potion
                     {
                         _currentRecipe = recipe;
                         _currentRecipeIndex = 0;
-                        _cauldronTimer.TimerIsActive = true;
+                        //_cauldronTimer.TimerIsActive = true;
                         break;
                     }
                 }
@@ -93,7 +93,7 @@ namespace MoonlitMixes.Potion
             }
 
             _ingredentToAdd = ingredient;
-            _cauldronTimer.ResetCooldown();
+            //_cauldronTimer.ResetCooldown();
             TriggerBubbleVFX();
             _needItem = false;
             _needMix = true;
@@ -112,7 +112,7 @@ namespace MoonlitMixes.Potion
                 _currentIngredients.Add(ingredient);
                 _needMix = false;
                 _currentRecipeIndex++;
-                _cauldronTimer.ResetCooldown();
+                //_cauldronTimer.ResetCooldown();
                 CheckRecipeCompletion();
             }
         
@@ -147,7 +147,7 @@ namespace MoonlitMixes.Potion
         {
             _needItem = true;
             _currentRecipe = null;
-            _cauldronTimer.StopCooldown();
+            //_cauldronTimer.StopCooldown();
 
             _potionListData.PotionResults.Add(recipe.Potion);
 
@@ -159,7 +159,7 @@ namespace MoonlitMixes.Potion
         {
             _needItem = true;
             _currentRecipe = null;
-            _cauldronTimer.StopCooldown();
+            //_cauldronTimer.StopCooldown();
 
             _cauldronMixing.DesactiveQTE();
             

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -1,12 +1,10 @@
+using MoonlitMixes.CookingMachine;
+using MoonlitMixes.Datas;
+using MoonlitMixes.Item;
+using MoonlitMixes.Player;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using MoonlitMixes.CookingMachine;
-using MoonlitMixes.Datas;
-using MoonlitMixes.Inputs;
-using MoonlitMixes.Item;
-using MoonlitMixes.Player;
-using MoonlitMixes.Potion;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -14,23 +12,34 @@ namespace MoonlitMixes.Potion
 {
     public class CauldronRecipeChecker : MonoBehaviour
     {
-        [SerializeField] private GameObject _interactUI;
-        [SerializeField] private ParticleSystem _bubbleVFX;
-        [SerializeField] private ParticleSystem _burnPot;
+        [Header("Recipe Configuration")]
+        [Tooltip("Liste de toutes les recettes possibles à vérifier.")]
         [SerializeField] private List<Recipe> _allRecipes;
+
+        [Tooltip("Liste des ingrédients actuellement dans le chaudron.")]
         [SerializeField] private List<ItemData> _currentIngredients = new List<ItemData>();
+
+        [Tooltip("Référence à l'objet Scriptable contenant les potions que le player peut créer.")]
         [SerializeField] private PotionListData _potionListData;
 
         private CauldronTimer _cauldronTimer;
-        private bool _isActive = false;
-        private PotionInventory _potionInventory;
         private CauldronMixing _cauldronMixing;
+        private CauldronVFXController _cauldronVFXController;
+
+
+        private bool _isActive = false;
         private bool _qteSuccess;
-        public bool _qteInProgress = false;
+        private bool _qteInProgress = false;
         private Recipe _currentRecipe;
         private int _currentRecipeIndex;
         private bool _needItem = true;
-        private ItemData _ingredentToAdd;
+        private ItemData _ingredientToAdd;
+
+        public bool QteInProgress
+        {
+            get => _qteInProgress;
+            set => _qteInProgress = value;
+        }
 
         public bool NeedItem
         {
@@ -42,18 +51,21 @@ namespace MoonlitMixes.Potion
         {
             _cauldronMixing = GetComponent<CauldronMixing>();
             _cauldronTimer = GetComponent<CauldronTimer>();
-            _potionInventory = FindFirstObjectByType<PotionInventory>();
+            _cauldronVFXController = GetComponent<CauldronVFXController>();
 
             if (_cauldronTimer == null)
             {
                 Debug.LogError("CauldronTimer n'est pas attaché au chaudron !");
             }
+            if (_cauldronVFXController == null)
+            {
+                Debug.LogError("CauldronVFXController n'est pas attaché au chaudron !");
+            }
         }
 
-        public void TogleShowInteractivity()
+        public void ToggleShowInteractivity()
         {
             _isActive = !_isActive;
-            //_interactUI.SetActive(_isActive);
         }
 
         public void AddIngredient(ItemData ingredient)
@@ -63,22 +75,7 @@ namespace MoonlitMixes.Potion
 
             if (!_currentIngredients.Any())
             {
-                foreach (Recipe recipe in _allRecipes)
-                {
-                    if (recipe.RequiredIngredients[0] == ingredient)
-                    {
-                        _currentRecipe = recipe;
-                        _currentRecipeIndex = 0;
-                        break;
-                    }
-                }
-
-                if (_currentRecipe == null)
-                {
-                    Debug.Log("Recipe is null");
-                    TriggerBurnPot();
-                    return;
-                }
+                InitializeRecipeWithFirstIngredient(ingredient);
             }
 
             if (_currentRecipe == null || ingredient != _currentRecipe.RequiredIngredients[_currentRecipeIndex])
@@ -87,22 +84,13 @@ namespace MoonlitMixes.Potion
                 return;
             }
 
-            _ingredentToAdd = ingredient;
-            TriggerBubbleVFX();
+            _ingredientToAdd = ingredient;
             _needItem = false;
+            _cauldronVFXController.PlayBubble();
 
             if (ingredient.CanBeStirred)
             {
-                _qteInProgress = true;
-                PlayerInteraction playerInteraction = FindFirstObjectByType<PlayerInteraction>();
-
-                PlayerInput input = playerInteraction.GetComponent<PlayerInput>();
-                if (input != null)
-                {
-                    input.SwitchCurrentActionMap("QTE");
-                }
-
-                _cauldronMixing.ConvertItem(playerInteraction);
+                StartQTEForStirring(ingredient);
             }
             else
             {
@@ -110,15 +98,41 @@ namespace MoonlitMixes.Potion
             }
         }
 
+        private void InitializeRecipeWithFirstIngredient(ItemData ingredient)
+        {
+            foreach (Recipe recipe in _allRecipes)
+            {
+                if (recipe.RequiredIngredients[0] == ingredient)
+                {
+                    _currentRecipe = recipe;
+                    _currentRecipeIndex = 0;
+                    break;
+                }
+            }
+
+            if (_currentRecipe == null)
+            {
+                Debug.Log("Recipe is null");
+                _cauldronVFXController.PlayBurned();
+            }
+        }
+
+        private void StartQTEForStirring(ItemData ingredient)
+        {
+            QteInProgress = true;
+            PlayerInteraction playerInteraction = FindFirstObjectByType<PlayerInteraction>();
+            PlayerInput input = playerInteraction.GetComponent<PlayerInput>();
+            input?.SwitchCurrentActionMap("QTE");
+
+            _cauldronMixing.ConvertItem(playerInteraction);
+        }
+
         private IEnumerator HandleIngredientWithoutStir(ItemData ingredient)
         {
             _cauldronTimer.PotionSuccessExpected = true;
-
             Recipe localRecipe = _currentRecipe;
 
             _cauldronTimer.StartCooldown();
-            Debug.Log("StartCooldown");
-
             yield return new WaitForSeconds(_cauldronTimer.RemainingTime);
 
             if (_currentRecipe != localRecipe)
@@ -143,16 +157,13 @@ namespace MoonlitMixes.Potion
             {
                 _currentIngredients.Add(ingredient);
                 _currentRecipeIndex++;
-
                 _cauldronTimer.ResetCooldown();
                 _cauldronTimer.TimerIsActive = true;
-                Debug.Log("Success without QTE");
 
                 CheckRecipeCompletion();
             }
             else
             {
-                Debug.Log("Failed without QTE");
                 HandleFailedPotion();
             }
         }
@@ -168,7 +179,6 @@ namespace MoonlitMixes.Potion
 
             if (!_qteSuccess)
             {
-                Debug.Log("Failed QTE");
                 HandleFailedPotion();
                 return;
             }
@@ -177,16 +187,13 @@ namespace MoonlitMixes.Potion
             {
                 _currentIngredients.Add(ingredient);
                 _currentRecipeIndex++;
-
                 _cauldronTimer.ResetCooldown();
                 _cauldronTimer.TimerIsActive = true;
-                Debug.Log("Success with QTE");
 
                 CheckRecipeCompletion();
             }
             else
             {
-                Debug.Log("Failed QTE logic");
                 HandleFailedPotion();
             }
         }
@@ -195,7 +202,6 @@ namespace MoonlitMixes.Potion
         {
             if (IsRecipeComplete(_currentRecipe))
             {
-                Debug.Log("Succes");
                 HandleSuccessfulPotion(_currentRecipe);
             }
             else
@@ -214,72 +220,33 @@ namespace MoonlitMixes.Potion
             _needItem = true;
             _currentRecipe = null;
             _cauldronTimer.StopCooldown();
-
             _potionListData.PotionResults.Add(recipe.Potion);
-
             _currentIngredients.Clear();
-            _ingredentToAdd = null;
+            _ingredientToAdd = null;
         }
 
         private void HandleFailedPotion()
         {
+            _cauldronVFXController.PlayBurned();
             _needItem = true;
             _currentRecipe = null;
             _cauldronTimer.StopCooldown();
-
             _cauldronMixing.DesactiveQTE();
-
             _currentIngredients.Clear();
-            _ingredentToAdd = null;
-        }
-
-        private void TriggerBurnPot()
-        {
-            if (_burnPot != null)
-            {
-                _burnPot.Play();
-                Invoke(nameof(DisableBurnPot), _burnPot.main.duration);
-            }
-        }
-
-        private void DisableBurnPot()
-        {
-            if (_burnPot != null)
-            {
-                _burnPot.Stop();
-            }
-        }
-
-        private void TriggerBubbleVFX()
-        {
-            if (_bubbleVFX != null)
-            {
-                _bubbleVFX.Play();
-                Invoke(nameof(DisableBubbleVFX), _bubbleVFX.main.duration);
-            }
-        }
-
-        private void DisableBubbleVFX()
-        {
-            if (_bubbleVFX != null)
-            {
-                _bubbleVFX.Stop();
-            }
+            _ingredientToAdd = null;
         }
 
         public void CheckQTE(bool state)
         {
-            _qteInProgress = false;
-
+            QteInProgress = false;
             _qteSuccess = state;
 
             if (state)
             {
-                ValidateIngredientAddition(_ingredentToAdd);
+                ValidateIngredientAddition(_ingredientToAdd);
             }
             else
             {
-                Debug.Log("Failed QTE");
                 HandleFailedPotion();
             }
         }

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -38,6 +38,9 @@ namespace MoonlitMixes.Potion
         private int _currentRecipeIndex;
         private bool _needItem = true;
         private ItemData _ingredientToAdd;
+        private bool _cooldownCoroutineRunning = false;
+        private Coroutine _currentCooldownCoroutine;
+
 
         public bool QteInProgress
         {
@@ -88,6 +91,19 @@ namespace MoonlitMixes.Potion
                 return;
             }
 
+            // Si on est dans la phase attente, on relance le timer (phase validation)
+            if (_cauldronTimer.WaitingForNextIngredient)
+            {
+                _cauldronTimer.WaitingForNextIngredient = false;
+                _cauldronTimer.ResetCooldown();
+                _cauldronTimer.TimerIsActive = true;
+            }
+            else if (_currentCooldownCoroutine != null)
+            {
+                StopCoroutine(_currentCooldownCoroutine);
+                Debug.Log("Ancien timer interrompu.");
+            }
+
             _ingredientToAdd = ingredient;
             _needItem = false;
             _cauldronVFXController.PlayBubble();
@@ -98,7 +114,8 @@ namespace MoonlitMixes.Potion
             }
             else
             {
-                StartCoroutine(HandleIngredientWithoutStir(ingredient));
+                _cauldronTimer.PotionSuccessExpected = true;
+                _cauldronTimer.StartCooldown();
             }
         }
 
@@ -137,23 +154,35 @@ namespace MoonlitMixes.Potion
 
         private IEnumerator HandleIngredientWithoutStir(ItemData ingredient)
         {
+            _cooldownCoroutineRunning = true;
+
             _cauldronTimer.PotionSuccessExpected = true;
             Recipe localRecipe = _currentRecipe;
 
             _cauldronTimer.StartCooldown();
-            yield return new WaitForSeconds(_cauldronTimer.RemainingTime);
+            float duration = _cauldronTimer.RemainingTime;
+            float elapsed = 0f;
 
-            if (_currentRecipe != localRecipe)
+            while (elapsed < duration)
             {
-                Debug.LogWarning("Recette modifiée pendant le cooldown.");
-                yield break;
+                yield return null;
+                elapsed += Time.deltaTime;
             }
 
             ValidateIngredientWithoutQTE(ingredient);
+            _cooldownCoroutineRunning = false;
+            _currentCooldownCoroutine = null;
+
         }
 
         private void ValidateIngredientWithoutQTE(ItemData ingredient)
         {
+            Debug.Log($"VALIDATE WITHOUT QTE: Recipe = {_currentRecipe?.name}, Index = {_currentRecipeIndex}, Ingredient = {ingredient.name}, Expected = {_currentRecipe?.RequiredIngredients[_currentRecipeIndex].name}");
+
+            Debug.Log("Validate sans QTE");
+            _cooldownCoroutineRunning = false;
+            _currentCooldownCoroutine = null;
+
             if (_currentRecipe == null)
             {
                 Debug.LogWarning("ValidateIngredientAddition appelé sans recette active !");
@@ -163,10 +192,9 @@ namespace MoonlitMixes.Potion
 
             if (_currentRecipe.RequiredIngredients[_currentRecipeIndex] == ingredient)
             {
+                Debug.Log("ingédient good");
                 _currentIngredients.Add(ingredient);
                 _currentRecipeIndex++;
-                _cauldronTimer.ResetCooldown();
-                _cauldronTimer.TimerIsActive = true;
 
                 CheckRecipeCompletion();
             }
@@ -178,6 +206,7 @@ namespace MoonlitMixes.Potion
 
         private void ValidateIngredientAddition(ItemData ingredient)
         {
+            Debug.Log("Validate QTE");
             if (_currentRecipe == null)
             {
                 Debug.LogWarning("ValidateIngredientAddition appelé sans recette active !");
@@ -233,8 +262,13 @@ namespace MoonlitMixes.Potion
             _ingredientToAdd = null;
         }
 
-        private void HandleFailedPotion()
+        public void HandleFailedPotion()
         {
+            Debug.LogWarning("💥 Potion échouée — état courant: " +
+                 $"Recipe = {_currentRecipe?.name}, Index = {_currentRecipeIndex}, Ingredients = {_currentIngredients.Count}");
+
+            _cooldownCoroutineRunning = false;
+
             _cauldronVFXController.PlayBurned();
             _needItem = true;
             _currentRecipe = null;
@@ -242,6 +276,17 @@ namespace MoonlitMixes.Potion
             _cauldronMixing.DesactiveQTE();
             _currentIngredients.Clear();
             _ingredientToAdd = null;
+            _cauldronTimer.CanAction = true;
+            _cauldronTimer.TimerIsActive = false;
+            _cauldronTimer.PotionSuccessExpected = false;
+        }
+
+        public void ValidateIngredientAfterTimer()
+        {
+            if (_ingredientToAdd != null)
+            {
+                ValidateIngredientWithoutQTE(_ingredientToAdd);
+            }
         }
 
         public void CheckQTE(bool state)

--- a/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronRecipeChecker.cs
@@ -30,7 +30,6 @@ namespace MoonlitMixes.Potion
         private CauldronMixing _cauldronMixing;
         private CauldronVFXController _cauldronVFXController;
 
-
         private bool _isActive = false;
         private bool _qteSuccess;
         private bool _qteInProgress = false;
@@ -40,7 +39,6 @@ namespace MoonlitMixes.Potion
         private ItemData _ingredientToAdd;
         private bool _cooldownCoroutineRunning = false;
         private Coroutine _currentCooldownCoroutine;
-
 
         public bool QteInProgress
         {

--- a/Assets/_Core/Scripts/Potion/CauldronTimer.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronTimer.cs
@@ -6,7 +6,9 @@ namespace MoonlitMixes.Potion
 {
     public class CauldronTimer : MonoBehaviour
     {
-        [Header("Cooldown Durations")]
+        public bool PotionSuccessExpected { get; set; }
+
+        [Header("Cooldown Duration")]
         [SerializeField] private float _itemCooldown = 60f;
 
         [Header("Images Of Progress Bar")]
@@ -81,27 +83,31 @@ namespace MoonlitMixes.Potion
                 //Debug.Log($"Cooldown restant: {_remainingTime:F2} secondes");
             }
             else if (_remainingTime >= 0)
-            {   
+            {
                 _remainingTime -= Time.fixedDeltaTime;
                 _canAction = true;
                 _fillBarBackValue = _remainingTime / _itemCooldown * 2;
                 _fillBarBack.fillAmount = _fillBarBackValue;
-                
-                if(!_isSmokeVFXUp)
+
+                if (!_isSmokeVFXUp && !PotionSuccessExpected)
                 {
                     _smokeVFX.Play();
                     _isSmokeVFXUp = true;
                 }
                 //Debug.Log($"Cooldown restant avant cramé: {_remainingTime:F2} secondes");
             }
-            else if(!_timerFinished)
+            else if (!_timerFinished)
             {
                 _canAction = false;
                 _timerIsActive = false;
                 _timerFinished = true;
-                _cauldronRecipeChecker.CheckQTE(false);
-    
-                if(!_isBurnVFXUp)
+
+                if (_cauldronRecipeChecker._qteInProgress)
+                {
+                    _cauldronRecipeChecker.CheckQTE(false);
+                }
+
+                if (!_isBurnVFXUp && !PotionSuccessExpected)
                 {
                     _burnedVFX.Play();
                     _isBurnVFXUp = true;

--- a/Assets/_Core/Scripts/Potion/CauldronTimer.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronTimer.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 using MoonlitMixes.CookingMachine;
 
@@ -15,7 +15,6 @@ namespace MoonlitMixes.Potion
         [SerializeField] private Image _fillBarFront;
         [SerializeField] private Image _fillBarBack;
 
-
         private float _fillBarFrontValue;
         private float _fillBarBackValue;
         private float _remainingTime;
@@ -29,6 +28,7 @@ namespace MoonlitMixes.Potion
         private bool _isSmokeVFXUp;
         private bool _isBurnVFXUp;
         private bool _isFireVFXUp;
+        public bool WaitingForNextIngredient = false;
 
         public bool CanAction
         {
@@ -57,48 +57,77 @@ namespace MoonlitMixes.Potion
         {
             if (!_timerIsActive) return;
 
-            if (_remainingTime >= _itemCooldown / 2)
+            if (!WaitingForNextIngredient)
             {
-                _remainingTime -= Time.fixedDeltaTime;
-                _fillBarFrontValue = _remainingTime / _itemCooldown * 2;
-                _fillBarFront.fillAmount = _fillBarFrontValue - 1;
-                _canAction = false;
+                // Phase 1 : validation de l'item ajouté (première moitié du timer)
+                if (_remainingTime >= _itemCooldown / 2)
+                {
+                    _remainingTime -= Time.fixedDeltaTime;
+                    _fillBarFrontValue = _remainingTime / _itemCooldown * 2;
+                    _fillBarFront.fillAmount = _fillBarFrontValue - 1;
+                    _canAction = false;
 
-                if (!_isBubbleVFXUp)
-                {
-                    _cauldronVFXController.PlayBubble();
+                    if (!_isBubbleVFXUp)
+                    {
+                        _cauldronVFXController.PlayBubble();
+                    }
+                    if (!_isFireVFXUp)
+                    {
+                        _cauldronVFXController.PlayFire();
+                    }
                 }
-                if (!_isFireVFXUp)
+                else
                 {
-                    _cauldronVFXController.PlayFire();
+                    if (PotionSuccessExpected)
+                    {
+                        _cauldronRecipeChecker.ValidateIngredientAfterTimer();
+                        PotionSuccessExpected = false;
+                    }
+
+                    // Fin phase 1 → passer à la phase 2 (attente ingrédient)
+                    WaitingForNextIngredient = true;
+                    _remainingTime = _itemCooldown / 2;
+                    _canAction = true;
+
+                    if (_cauldronRecipeChecker != null)
+                        _cauldronRecipeChecker.NeedItem = true;
                 }
             }
-            else if (_remainingTime >= 0)
+            else
             {
-                _remainingTime -= Time.fixedDeltaTime;
-                _canAction = true;
-                _fillBarBackValue = _remainingTime / _itemCooldown * 2;
-                _fillBarBack.fillAmount = _fillBarBackValue;
-
-                if (!_isSmokeVFXUp && !PotionSuccessExpected)
+                // Phase 2 : attente d'un nouvel ingrédient (seconde moitié)
+                if (_remainingTime > 0)
                 {
-                    _cauldronVFXController.PlaySmoke();
+                    _remainingTime -= Time.fixedDeltaTime;
+                    _fillBarBackValue = _remainingTime / (_itemCooldown / 2);
+                    _fillBarBack.fillAmount = _fillBarBackValue;
+
+                    if (!_isSmokeVFXUp && !PotionSuccessExpected)
+                    {
+                        _cauldronVFXController.PlaySmoke();
+                        _isSmokeVFXUp = true;
+                    }
                 }
-            }
-            else if (!_timerFinished)
-            {
-                _canAction = false;
-                _timerIsActive = false;
-                _timerFinished = true;
-
-                if (_cauldronRecipeChecker.QteInProgress)
+                else
                 {
-                    _cauldronRecipeChecker.CheckQTE(false);
-                }
+                    // Timer fini en phase d'attente => potion ratée
+                    _timerIsActive = false;
+                    _timerFinished = true;
 
-                if (!_isBurnVFXUp && !PotionSuccessExpected)
-                {
-                    _cauldronVFXController.PlayBurned();
+                    if (_cauldronRecipeChecker.QteInProgress)
+                    {
+                        _cauldronRecipeChecker.CheckQTE(false);
+                    }
+                    else
+                    {
+                        _cauldronRecipeChecker.HandleFailedPotion();
+                    }
+
+                    if (!_isBurnVFXUp && !PotionSuccessExpected)
+                    {
+                        _cauldronVFXController.PlayBurned();
+                        _isBurnVFXUp = true;
+                    }
                 }
             }
         }
@@ -122,8 +151,10 @@ namespace MoonlitMixes.Potion
 
         public void ResetCooldown()
         {
-            _timerFinished = false;
             _remainingTime = _itemCooldown;
+            TimerIsActive = true;
+            CanAction = false;
+            _timerFinished = false;
             _fillBarBack.fillAmount = 1;
             _fillBarFront.fillAmount = 1;
             _fillBarFrontValue = _remainingTime * .5f;
@@ -141,6 +172,10 @@ namespace MoonlitMixes.Potion
             _fillBarFront.fillAmount = 0;
             _canAction = true;
 
+            _isFireVFXUp = false;
+            _isBubbleVFXUp = false;
+            _isSmokeVFXUp = false;
+            _isBurnVFXUp = true;
             _cauldronVFXController.StopFire();
         }
     }

--- a/Assets/_Core/Scripts/Potion/CauldronTimer.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronTimer.cs
@@ -94,7 +94,7 @@ namespace MoonlitMixes.Potion
                 _canAction = false;
                 _timerIsActive = false;
                 _timerFinished = true;
-                _cauldronRecipeChecker.NeedMix = false;
+                //_cauldronRecipeChecker.NeedMix = false;
                 _cauldronRecipeChecker.CheckQTE(false);
     
                 if(!_isBurnVFXUp)

--- a/Assets/_Core/Scripts/Potion/CauldronTimer.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronTimer.cs
@@ -15,72 +15,63 @@ namespace MoonlitMixes.Potion
         [SerializeField] private Image _fillBarFront;
         [SerializeField] private Image _fillBarBack;
 
-        [Header("VFX")]
-        [SerializeField] private ParticleSystem _bubbleVFX;
-        [SerializeField] private ParticleSystem _smokeVFX;
-        [SerializeField] private ParticleSystem _burnedVFX;
-        [SerializeField] private ParticleSystem[] _fireVFXArray;
-    
+
         private float _fillBarFrontValue;
         private float _fillBarBackValue;
         private float _remainingTime;
-        
+
+        private CauldronVFXController _cauldronVFXController;
         private CauldronRecipeChecker _cauldronRecipeChecker;
         private bool _timerFinished;
         private bool _timerIsActive;
         private bool _canAction = true;
+        private bool _isBubbleVFXUp;
         private bool _isSmokeVFXUp;
         private bool _isBurnVFXUp;
-        private bool _isBubbleVFXUp;
         private bool _isFireVFXUp;
-        
+
         public bool CanAction
         {
             get => _canAction;
             set => _canAction = value;
         }
-        
+
         public bool TimerIsActive
         {
             get => _timerIsActive;
             set => _timerIsActive = value;
         }
-        
+
         public float RemainingTime
         {
             get => _remainingTime;
         }
-    
+
         private void Awake()
         {
             _cauldronRecipeChecker = GetComponent<CauldronRecipeChecker>();
+            _cauldronVFXController = GetComponent<CauldronVFXController>();
         }
-    
+
         private void FixedUpdate()
-        {        
-            if(!_timerIsActive) return;
-            
-            if (_remainingTime >= _itemCooldown/2)
+        {
+            if (!_timerIsActive) return;
+
+            if (_remainingTime >= _itemCooldown / 2)
             {
                 _remainingTime -= Time.fixedDeltaTime;
                 _fillBarFrontValue = _remainingTime / _itemCooldown * 2;
                 _fillBarFront.fillAmount = _fillBarFrontValue - 1;
                 _canAction = false;
-                
-                if(!_isBubbleVFXUp)
+
+                if (!_isBubbleVFXUp)
                 {
-                    _bubbleVFX.Play();
-                    _isBubbleVFXUp = true;
+                    _cauldronVFXController.PlayBubble();
                 }
-                if(!_isFireVFXUp)
+                if (!_isFireVFXUp)
                 {
-                    foreach(ParticleSystem fireVFX in _fireVFXArray)
-                    {
-                        fireVFX.Play();
-                    }
-                    _isFireVFXUp = true;
+                    _cauldronVFXController.PlayFire();
                 }
-                //Debug.Log($"Cooldown restant: {_remainingTime:F2} secondes");
             }
             else if (_remainingTime >= 0)
             {
@@ -91,10 +82,8 @@ namespace MoonlitMixes.Potion
 
                 if (!_isSmokeVFXUp && !PotionSuccessExpected)
                 {
-                    _smokeVFX.Play();
-                    _isSmokeVFXUp = true;
+                    _cauldronVFXController.PlaySmoke();
                 }
-                //Debug.Log($"Cooldown restant avant cramé: {_remainingTime:F2} secondes");
             }
             else if (!_timerFinished)
             {
@@ -102,17 +91,15 @@ namespace MoonlitMixes.Potion
                 _timerIsActive = false;
                 _timerFinished = true;
 
-                if (_cauldronRecipeChecker._qteInProgress)
+                if (_cauldronRecipeChecker.QteInProgress)
                 {
                     _cauldronRecipeChecker.CheckQTE(false);
                 }
 
                 if (!_isBurnVFXUp && !PotionSuccessExpected)
                 {
-                    _burnedVFX.Play();
-                    _isBurnVFXUp = true;
+                    _cauldronVFXController.PlayBurned();
                 }
-                //Debug.Log("Le cooldown est termin�. Vous pouvez ajouter un nouvel �l�ment !");
             }
         }
 
@@ -126,7 +113,7 @@ namespace MoonlitMixes.Potion
 
             _isSmokeVFXUp = false;
             _isBurnVFXUp = false;
-            _isBubbleVFXUp = false;
+            _isBubbleVFXUp = true;
             _isFireVFXUp = false;
 
             _timerIsActive = true;
@@ -153,11 +140,8 @@ namespace MoonlitMixes.Potion
             _fillBarBack.fillAmount = 0;
             _fillBarFront.fillAmount = 0;
             _canAction = true;
-            
-            foreach(ParticleSystem fireVFX in _fireVFXArray)
-            {
-                fireVFX.Stop();
-            }
+
+            _cauldronVFXController.StopFire();
         }
     }
 }

--- a/Assets/_Core/Scripts/Potion/CauldronTimer.cs
+++ b/Assets/_Core/Scripts/Potion/CauldronTimer.cs
@@ -6,9 +6,14 @@ namespace MoonlitMixes.Potion
 {
     public class CauldronTimer : MonoBehaviour
     {
+        [Header("Cooldown Durations")]
         [SerializeField] private float _itemCooldown = 60f;
+
+        [Header("Images Of Progress Bar")]
         [SerializeField] private Image _fillBarFront;
         [SerializeField] private Image _fillBarBack;
+
+        [Header("VFX")]
         [SerializeField] private ParticleSystem _bubbleVFX;
         [SerializeField] private ParticleSystem _smokeVFX;
         [SerializeField] private ParticleSystem _burnedVFX;
@@ -94,7 +99,6 @@ namespace MoonlitMixes.Potion
                 _canAction = false;
                 _timerIsActive = false;
                 _timerFinished = true;
-                //_cauldronRecipeChecker.NeedMix = false;
                 _cauldronRecipeChecker.CheckQTE(false);
     
                 if(!_isBurnVFXUp)
@@ -105,9 +109,27 @@ namespace MoonlitMixes.Potion
                 //Debug.Log("Le cooldown est termin�. Vous pouvez ajouter un nouvel �l�ment !");
             }
         }
-    
+
+        public void StartCooldown()
+        {
+            _remainingTime = _itemCooldown;
+            _fillBarBack.fillAmount = 1f;
+            _fillBarFront.fillAmount = 1f;
+            _fillBarFrontValue = _remainingTime * 0.5f;
+            _fillBarBackValue = _remainingTime * 0.5f;
+
+            _isSmokeVFXUp = false;
+            _isBurnVFXUp = false;
+            _isBubbleVFXUp = false;
+            _isFireVFXUp = false;
+
+            _timerIsActive = true;
+            _canAction = false;
+        }
+
         public void ResetCooldown()
         {
+            _timerFinished = false;
             _remainingTime = _itemCooldown;
             _fillBarBack.fillAmount = 1;
             _fillBarFront.fillAmount = 1;
@@ -117,7 +139,7 @@ namespace MoonlitMixes.Potion
             _isBurnVFXUp = false;
             _isBubbleVFXUp = false;
         }
-    
+
         public void StopCooldown()
         {
             _remainingTime = _itemCooldown;

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _elementType: 0
   _rarity: 1
   _itemUsage: 3
-  _canBeStirred: 0
+  _canBeStirred: 1
   _sprite: {fileID: 21300000, guid: 524ece39f495b2742880c9c7dbdb67cd, type: 3}
   _itemToConvert: {fileID: 0}
   _description: 

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _elementType: 0
   _rarity: 1
   _itemUsage: 3
-  _canBeStirred: 1
+  _canBeStirred: 0
   _sprite: {fileID: 21300000, guid: 524ece39f495b2742880c9c7dbdb67cd, type: 3}
   _itemToConvert: {fileID: 0}
   _description: 

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
@@ -16,9 +16,8 @@ MonoBehaviour:
   _elementType: 0
   _rarity: 1
   _itemUsage: 3
-  _canBeStirred: 0
+  _canBeStirred: 1
   _sprite: {fileID: 21300000, guid: 524ece39f495b2742880c9c7dbdb67cd, type: 3}
   _itemToConvert: {fileID: 0}
   _description: 
   _itemPrefab: {fileID: 2971309982563147035, guid: 3da282355a56c1a4a93f81d4e14d0706, type: 3}
-  _state: 3

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Bark_Earth.asset
@@ -16,6 +16,7 @@ MonoBehaviour:
   _elementType: 0
   _rarity: 1
   _itemUsage: 3
+  _canBeStirred: 1
   _sprite: {fileID: 21300000, guid: 524ece39f495b2742880c9c7dbdb67cd, type: 3}
   _itemToConvert: {fileID: 0}
   _description: 

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Recipe.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Recipe.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   _recipeName: Bark Test
   _requiredIngredients:
   - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
+  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
   _potionSprite: {fileID: -880875579, guid: 4860c3f61dd41394e84402257d7897d8, type: 3}
   _description: 
   _potion: {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/PotionListTest/PotionListDataTest.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/PotionListTest/PotionListDataTest.asset
@@ -12,4 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e6fbb15bd61b78e48ac1cb4030251edc, type: 3}
   m_Name: PotionListDataTest
   m_EditorClassIdentifier: 
-  potionResults: []
+  potionResults:
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/PotionListTest/PotionListDataTest.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/PotionListTest/PotionListDataTest.asset
@@ -12,5 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e6fbb15bd61b78e48ac1cb4030251edc, type: 3}
   m_Name: PotionListDataTest
   m_EditorClassIdentifier: 
-  potionResults:
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  potionResults: []

--- a/Assets/_Core/Scripts/VFX.meta
+++ b/Assets/_Core/Scripts/VFX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c203642510fac349b1308c5790e3d4d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Core/Scripts/VFX/CauldronVFXController.cs
+++ b/Assets/_Core/Scripts/VFX/CauldronVFXController.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+using System;
+
+public class CauldronVFXController : MonoBehaviour
+{
+    [SerializeField] private ParticleSystem _bubbleVFX;
+    [SerializeField] private ParticleSystem _smokeVFX;
+    [SerializeField] private ParticleSystem _burnedVFX;
+    [SerializeField] private ParticleSystem[] _fireVFXArray;
+
+    private bool _isFireActive = false;
+
+    public void PlayBubble()
+    {
+        if (_bubbleVFX != null)
+        {
+            _bubbleVFX.Play();
+        }
+        else
+        {
+            Debug.LogError("Bubble VFX is not assigned!");
+        }
+    }
+
+    public void PlaySmoke()
+    {
+        if (_smokeVFX != null)
+        {
+            _smokeVFX.Play();
+        }
+        else
+        {
+            Debug.LogError("Smoke VFX is not assigned!");
+        }
+    }
+
+    public void PlayBurned()
+    {
+        if (_burnedVFX != null)
+        {
+            _burnedVFX.Play();
+        }
+        else
+        {
+            Debug.LogError("Burned VFX is not assigned!");
+        }
+    }
+
+    public void PlayFire()
+    {
+        if (!_isFireActive)
+        {
+            if (_fireVFXArray != null && _fireVFXArray.Length > 0)
+            {
+                foreach (var fx in _fireVFXArray)
+                {
+                    if (fx != null)
+                    {
+                        fx.Play();
+                    }
+                    else
+                    {
+                        Debug.LogError("One of the fire VFX is not assigned!");
+                    }
+                }
+                _isFireActive = true;
+            }
+            else
+            {
+                Debug.LogError("Fire VFX array is not assigned or empty!");
+            }
+        }
+    }
+
+    public void StopFire()
+    {
+        if (_isFireActive)
+        {
+            if (_fireVFXArray != null && _fireVFXArray.Length > 0)
+            {
+                foreach (var fx in _fireVFXArray)
+                {
+                    if (fx != null)
+                    {
+                        fx.Stop();
+                    }
+                }
+                _isFireActive = false;
+            }
+        }
+    }
+}

--- a/Assets/_Core/Scripts/VFX/CauldronVFXController.cs.meta
+++ b/Assets/_Core/Scripts/VFX/CauldronVFXController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88d8b041580134444a4eb216ad880ac6


### PR DESCRIPTION
### CauldronTimer

* **Ajout de la propriété `PotionSuccessExpected`** pour contrôler l'activation des effets visuels (fumée et brûler) en fonction de l’état de réussite de la potion.
* **Séparation de la méthode `StartCooldown()`** de `ResetCooldown()` pour clarifier l’intention lors du démarrage d’un cooldown.
* **Ajout d’une vérification sur `_qteInProgress`** avant d’appeler `CheckQTE(false)`, évitant des appels inutiles.
* **Prévention des effets visuels indésirables** (fumée ou brûler) si `PotionSuccessExpected` est vrai.
* **Réinitialisation de l’état des VFX dans `StartCooldown()`** pour éviter des effets résiduels.

---
### CauldronRecipeChecker

* **Ajout de la coroutine `HandleIngredientWithoutStir()`** pour gérer les ingrédients ne nécessitant pas de QTE, avec temporisation via `StartCooldown()`.
* **Introduction de la variable `_qteInProgress`** pour indiquer si un QTE est en cours, et éviter les conflits d’interaction.
* **Ajout du changement de `ActionMap` vers `"QTE"`** via le système `PlayerInput`, déclenché uniquement si l’ingrédient le nécessite.
* **Utilisation de `CanBeStirred` dans `ItemData`** pour distinguer les ingrédients QTE et non-QTE.
* **Renforcement de la sécurité avec une vérification de cohérence de la recette** dans les coroutines pour éviter les changements pendant l’attente.
* **Séparation claire de la validation des ingrédients** : avec (`ValidateIngredientAddition`) ou sans QTE (`ValidateIngredientWithoutQTE`).
* **Suppression de la variable `NeedMix`**, devenue obsolète avec la nouvelle logique orientée QTE/non-QTE.
* **Refactorisation de la méthode `AddIngredient()`** pour être plus lisible et mieux structurée selon le type d'ingrédient.
* **Regroupement de la réussite ou l’échec de potion** après traitement des ingrédients, avec des méthodes dédiées.

---
### Player Interaction

* **Ajout de la propriété `CurrentPlayerInput`** pour stocker la référence au `PlayerInput` dans `Awake()`, facilitant la gestion des inputs.
* **Suppression de la logique de mélange dans le chaudron (`NeedMix`)** pour centraliser la gestion des ingrédients directement dans le chaudron.
* **Élimination d’un `Raycast` inutile** dans la branche vide de l’interaction avec chaudron (cas sans item).
* **Amélioration de la lisibilité générale** : suppression de conditions inutiles et meilleure structuration de l’ordre des actions.
* **Regroupement de la logique d'interaction UI / WaitingTable** dans des blocs clairs, pour plus de cohérence avec l’approche QTE vs non-QTE.

---
### Item Data

* **Ajout de la propriété `CanBeStirred`** via un `getter/setter`
---

### CauldronVFXController

* **Création d'un script pour le comportement des vfx** pour les chaudrons et non pas les mettre directement dans les scripts qui les utilisaient
---

### StirCameraTransition

* Gère la transition entre deux caméras (caméra normale et caméra de remuage).
* S’active quand le joueur commence ou arrête de remuer (stir) une potion dans un chaudron.
* Change la priorité des caméras pour activer celle du remuage au bon moment.
* Se connecte aux événements `OnStirStarted` et `OnStirEnded` du chaudron dans `CauldronRecipeChecker`.
