### PR TITLE
Dev progess/add sprite opacity effect

### DIFF
--- a/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
+++ b/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
@@ -730,7 +730,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -2890,7 +2890,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -89,6 +89,11 @@ namespace MoonlitMixes.Dialogue
 
         public void DisplayNextDialogue()
         {
+            if (_isEffectRunning)
+            {
+                return;
+            }
+
             if (_dialogueIndex >= _currentDialogue.Lines.Length)
             {
                 EndDialogue();
@@ -113,6 +118,18 @@ namespace MoonlitMixes.Dialogue
                 return;
             }
 
+            // 👉 DIM DES AUTRES immédiatement
+            for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
+            {
+                if (i == speakerIndex) continue;
+
+                var otherSprite = _spriteSpeakerEffects[i];
+                var otherText = _textSpeakerEffects[i];
+
+                otherSprite?.DimEffect();
+                otherText?.DimEffect();
+            }
+
             for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
             {
                 var spriteEffect = _spriteSpeakerEffects[i];
@@ -128,13 +145,7 @@ namespace MoonlitMixes.Dialogue
                         spriteEffect.ResetEffect();
                         textEffect.ResetEffect();
 
-                        // On applique FadeIn *avant* le texte
                         StartCoroutine(PlayEffectsBeforeText(line, spriteEffect, textEffect, _textBoxes[speakerIndex]));
-                    }
-                    if (i != speakerIndex && !line.IsFadeEffect)
-                    {
-                        spriteEffect.DimEffect();
-                        textEffect.DimEffect();
                     }
                 }
             }
@@ -144,6 +155,8 @@ namespace MoonlitMixes.Dialogue
 
         private IEnumerator PlayEffectsBeforeText(DialogueLineData line, SpeakerEffect spriteEffect, SpeakerEffect textEffect, TMP_Text textBox)
         {
+            _isEffectRunning = true;
+
             if (line.Effect == SpeakerEffectType.FadeIn)
             {
                 yield return spriteEffect.PlayEffect(line.Effect);
@@ -157,6 +170,15 @@ namespace MoonlitMixes.Dialogue
             {
                 yield return spriteEffect.PlayEffect(line.Effect);
                 yield return textEffect.PlayEffect(line.Effect);
+            }
+
+            _isEffectRunning = false;
+
+            // Si on a skippé un effet, mais qu'on n’a pas encore avancé la ligne : on le fait maintenant
+            if (_hasSkippedEffect)
+            {
+                _hasSkippedEffect = false;
+                DisplayNextDialogue();
             }
         }
 

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -26,6 +26,8 @@ namespace MoonlitMixes.Dialogue
         private int _dialogueIndex = 0;
         private bool _isTyping = false;
         private bool _isSkipText = false;
+        private bool _isEffectRunning = false;
+        private bool _hasSkippedEffect = false;
 
         private PlayerInput _playerInput;
         private InputActionAsset _inputActionAsset;
@@ -62,7 +64,7 @@ namespace MoonlitMixes.Dialogue
             if (_inputActionAsset == null) return;
 
             _originalActionMap = _inputActionAsset.FindActionMap("Player");
-            var dialogueActionMap = _inputActionAsset.FindActionMap("Dialogue");
+            InputActionMap dialogueActionMap = _inputActionAsset.FindActionMap("Dialogue");
 
             if (_originalActionMap == null || dialogueActionMap == null)
             {
@@ -129,7 +131,7 @@ namespace MoonlitMixes.Dialogue
                         // On applique FadeIn *avant* le texte
                         StartCoroutine(PlayEffectsBeforeText(line, spriteEffect, textEffect, _textBoxes[speakerIndex]));
                     }
-                    if (!line.IsFadeEffect)
+                    if (i != speakerIndex && !line.IsFadeEffect)
                     {
                         spriteEffect.DimEffect();
                         textEffect.DimEffect();
@@ -194,7 +196,7 @@ namespace MoonlitMixes.Dialogue
             _inputActionAsset.FindActionMap("Dialogue")?.Disable();
             _originalActionMap?.Enable();
 
-            foreach (var textBox in _textBoxes)
+            foreach (TMP_Text textBox in _textBoxes)
             {
                 if (textBox != null)
                 {
@@ -208,17 +210,36 @@ namespace MoonlitMixes.Dialogue
 
         public void OnNextDialoguePressed(InputAction.CallbackContext ctx)
         {
-            if (ctx.performed)
+            if (!ctx.performed) return;
+
+            if (_isEffectRunning && !_hasSkippedEffect)
             {
-                if (_isTyping)
+                // Première pression pendant un effet : on skip l'effet
+                _hasSkippedEffect = true;
+
+                foreach (SpeakerEffect effect in _spriteSpeakerEffects)
                 {
-                    _isSkipText = true;
+                    if (effect != null)
+                        effect.SkipEffectNow = true;
                 }
-                else
+
+                foreach (SpeakerEffect effect in _textSpeakerEffects)
                 {
-                    DisplayNextDialogue();
+                    if (effect != null)
+                        effect.SkipEffectNow = true;
                 }
+
+                return; // ne passe pas à la ligne suivante tant que l’effet est en cours
             }
+
+            if (_isTyping)
+            {
+                _isSkipText = true;
+                return;
+            }
+
+            // Si pas d’effet en cours ou déjà skippé
+            DisplayNextDialogue();
         }
     }
 }

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -48,7 +48,6 @@ namespace MoonlitMixes.Dialogue
                 Debug.LogError("PlayerInput or InputActionAsset is missing in DialogueController!");
             }
 
-            // Lier les textes aux sprites
             for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
             {
                 if (i < _textBoxes.Length && _spriteSpeakerEffects[i] != null)
@@ -60,8 +59,7 @@ namespace MoonlitMixes.Dialogue
 
         public void StartDialogue(DialogueData dialogue)
         {
-            if (_inputActionAsset == null)
-                return;
+            if (_inputActionAsset == null) return;
 
             _originalActionMap = _inputActionAsset.FindActionMap("Player");
             var dialogueActionMap = _inputActionAsset.FindActionMap("Dialogue");
@@ -113,40 +111,51 @@ namespace MoonlitMixes.Dialogue
                 return;
             }
 
-            if (_spriteSpeakerEffects != null && _textSpeakerEffects != null)
+            for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
             {
-                for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
+                var spriteEffect = _spriteSpeakerEffects[i];
+                var textEffect = _textSpeakerEffects[i];
+
+                if (spriteEffect != null && textEffect != null)
                 {
-                    var spriteEffect = _spriteSpeakerEffects[i];
-                    var textEffect = _textSpeakerEffects[i];
+                    spriteEffect.SetDialogueLineData(line);
+                    textEffect.SetDialogueLineData(line);
 
-                    if (spriteEffect != null && textEffect != null)
+                    if (i == speakerIndex)
                     {
-                        spriteEffect.SetDialogueLineData(line);
-                        textEffect.SetDialogueLineData(line);
+                        spriteEffect.ResetEffect();
+                        textEffect.ResetEffect();
 
-                        if (i == speakerIndex)
-                        {
-                            // Quand le personnage parle, on réinitialise (opaque) son texte et son sprite
-                            spriteEffect.ResetEffect();
-                            textEffect.ResetEffect();
-
-                            ApplyEffect(line.Effect, spriteEffect);
-                            ApplyEffect(line.Effect, textEffect);
-                        }
-                        if (!line.IsFadeEffect)
-                        {
-                            spriteEffect.DimEffect();
-                            textEffect.DimEffect();
-                        }
+                        // On applique FadeIn *avant* le texte
+                        StartCoroutine(PlayEffectsBeforeText(line, spriteEffect, textEffect, _textBoxes[speakerIndex]));
+                    }
+                    if (!line.IsFadeEffect)
+                    {
+                        spriteEffect.DimEffect();
+                        textEffect.DimEffect();
                     }
                 }
             }
 
-            WriteText(line.Text, _textBoxes[speakerIndex]);
-            StartCoroutine(TypeText(line.Text, _textBoxes[speakerIndex]));
-
             _dialogueIndex++;
+        }
+
+        private IEnumerator PlayEffectsBeforeText(DialogueLineData line, SpeakerEffect spriteEffect, SpeakerEffect textEffect, TMP_Text textBox)
+        {
+            if (line.Effect == SpeakerEffectType.FadeIn)
+            {
+                yield return spriteEffect.PlayEffect(line.Effect);
+                yield return textEffect.PlayEffect(line.Effect);
+            }
+
+            WriteText(line.Text, textBox);
+            yield return StartCoroutine(TypeText(line.Text, textBox));
+
+            if (line.Effect == SpeakerEffectType.FadeOut)
+            {
+                yield return spriteEffect.PlayEffect(line.Effect);
+                yield return textEffect.PlayEffect(line.Effect);
+            }
         }
 
         private IEnumerator DisplayNextDialogueWithDelay()
@@ -163,11 +172,9 @@ namespace MoonlitMixes.Dialogue
 
         private IEnumerator TypeText(string text, TMP_Text textBox)
         {
+            _isTyping = true;
             for (int i = 0; i < text.Length; ++i)
             {
-                textBox.maxVisibleCharacters++;
-                _isTyping = true;
-
                 if (_isSkipText)
                 {
                     textBox.maxVisibleCharacters = text.Length;
@@ -175,35 +182,10 @@ namespace MoonlitMixes.Dialogue
                     break;
                 }
 
+                textBox.maxVisibleCharacters++;
                 yield return new WaitForSeconds(_letterDelay);
             }
-
             _isTyping = false;
-        }
-
-        private void ApplyEffect(SpeakerEffectType effectType, SpeakerEffect speaker)
-        {
-            switch (effectType)
-            {
-                case SpeakerEffectType.Tremble:
-                    speaker.ApplyEffect(effectType);
-                    break;
-
-                case SpeakerEffectType.Jump:
-                    speaker.ApplyEffect(effectType);
-                    break;
-
-                case SpeakerEffectType.FadeIn:
-                    speaker.ApplyEffect(effectType); 
-                    break;
-
-                case SpeakerEffectType.FadeOut: 
-                    speaker.ApplyEffect(effectType);
-                    break;
-
-                default:
-                    break;
-            }
         }
 
         public void EndDialogue()

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -134,9 +134,8 @@ namespace MoonlitMixes.Dialogue
                             ApplyEffect(line.Effect, spriteEffect);
                             ApplyEffect(line.Effect, textEffect);
                         }
-                        else
+                        if (!line.IsFadeEffect)
                         {
-                            // Les autres sont en dim
                             spriteEffect.DimEffect();
                             textEffect.DimEffect();
                         }
@@ -191,6 +190,14 @@ namespace MoonlitMixes.Dialogue
                     break;
 
                 case SpeakerEffectType.Jump:
+                    speaker.ApplyEffect(effectType);
+                    break;
+
+                case SpeakerEffectType.FadeIn:
+                    speaker.ApplyEffect(effectType); 
+                    break;
+
+                case SpeakerEffectType.FadeOut: 
                     speaker.ApplyEffect(effectType);
                     break;
 

--- a/Assets/_Core/Scripts/Dialogue/DialogueLineDataEditor.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueLineDataEditor.cs
@@ -1,24 +1,56 @@
 #if UNITY_EDITOR
 using UnityEditor;
+using UnityEngine;
 
 namespace MoonlitMixes.Datas
 {
     [CustomEditor(typeof(DialogueLineData))]
     public class DialogueLineDataEditor : Editor
     {
+        SerializedProperty _effectProp;
+        SerializedProperty _trembleXProp;
+        SerializedProperty _trembleYProp;
+        SerializedProperty _fadeInDurationProp;
+        SerializedProperty _fadeOutDurationProp;
+
+        void OnEnable()
+        {
+            _effectProp = serializedObject.FindProperty("_effect");
+            _trembleXProp = serializedObject.FindProperty("_trembleIntensityX");
+            _trembleYProp = serializedObject.FindProperty("_trembleIntensityY");
+            _fadeInDurationProp = serializedObject.FindProperty("_fadeInDuration");
+            _fadeOutDurationProp = serializedObject.FindProperty("_fadeOutDuration");
+        }
+
         public override void OnInspectorGUI()
         {
-            var dialogueLineData = (DialogueLineData)target;
+            serializedObject.Update();
 
-            DrawDefaultInspector();
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_text"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_speakerIndex"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_speakerSprite"));
+            EditorGUILayout.PropertyField(_effectProp);
 
-            if (dialogueLineData.IsTrembleEffect)
+            var effect = (SpeakerEffectType)_effectProp.enumValueIndex;
+
+            if (effect == SpeakerEffectType.Tremble)
             {
                 EditorGUILayout.Space();
-                dialogueLineData.TrembleIntensityX = EditorGUILayout.Slider("Tremble Intensity X", dialogueLineData.TrembleIntensityX, 0f, 10f);
-
-                dialogueLineData.TrembleIntensityY = EditorGUILayout.Slider("Tremble Intensity Y", dialogueLineData.TrembleIntensityY, 0f, 10f);
+                EditorGUILayout.Slider(_trembleXProp, 0f, 10f, new GUIContent("Tremble Intensity X"));
+                EditorGUILayout.Slider(_trembleYProp, 0f, 10f, new GUIContent("Tremble Intensity Y"));
             }
+            else if (effect == SpeakerEffectType.FadeIn)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.Slider(_fadeInDurationProp, 0.1f, 5f, new GUIContent("Fade In Duration"));
+            }
+            else if (effect == SpeakerEffectType.FadeOut)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.Slider(_fadeOutDurationProp, 0.1f, 5f, new GUIContent("Fade Out Duration"));
+            }
+
+            serializedObject.ApplyModifiedProperties();
         }
     }
 }

--- a/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
+++ b/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
@@ -14,6 +14,8 @@ namespace MoonlitMixes.Dialogue.Effect
         private TMP_Text _linkedText;
 
         private DialogueLineData _dialogueLineData;
+        private bool _isDimmed = false;
+
 
         private void Awake()
         {
@@ -47,6 +49,14 @@ namespace MoonlitMixes.Dialogue.Effect
 
                 case SpeakerEffectType.Jump:
                     StartCoroutine(JumpEffect());
+                    break;
+
+                case SpeakerEffectType.FadeIn:
+                    StartCoroutine(FadeInEffect());
+                    break;
+
+                case SpeakerEffectType.FadeOut:
+                    StartCoroutine(FadeOutEffect());
                     break;
 
                 default:
@@ -136,6 +146,8 @@ namespace MoonlitMixes.Dialogue.Effect
 
         public void DimEffect()
         {
+            _isDimmed = true;
+
             if (_image != null)
             {
                 _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 0.5f); // Sprite semi-transparent
@@ -149,6 +161,94 @@ namespace MoonlitMixes.Dialogue.Effect
                 var textColor = _linkedText.color;
                 _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 0.5f); // Texte semi-transparent
             }
+        }
+
+        private IEnumerator FadeInEffect()
+        {
+            _isDimmed = false;
+
+            if (_image)
+            {
+                _image.color = _originalColor;
+                RectTransform rectTransform = _image.rectTransform;
+                rectTransform.sizeDelta = new Vector2(_originalScale.x * 300f, _originalScale.y * 300f);
+            }
+
+            if (_linkedText)
+            {
+                var textColor = _linkedText.color;
+                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 0f);
+            }
+
+            float duration = _dialogueLineData != null ? _dialogueLineData.FadeInDuration : 0.5f;
+            float time = 0f;
+
+            while (time < duration)
+            {
+                float t = time / duration;
+                float alphaImage = Mathf.Lerp(0f, 1f, t);
+                float alphaText = Mathf.Lerp(0f, 1f, t);
+
+                if (_image)
+                {
+                    var color = _image.color;
+                    _image.color = new Color(color.r, color.g, color.b, alphaImage);
+                }
+
+                if (_linkedText)
+                {
+                    var color = _linkedText.color;
+                    _linkedText.color = new Color(color.r, color.g, color.b, alphaText);
+                }
+
+                time += Time.deltaTime;
+                yield return null;
+            }
+
+            if (_image)
+                _image.color = new Color(_image.color.r, _image.color.g, _image.color.b, 1f);
+
+            if (_linkedText)
+                _linkedText.color = new Color(_linkedText.color.r, _linkedText.color.g, _linkedText.color.b, 1f);
+        }
+
+        private IEnumerator FadeOutEffect()
+        {
+            _isDimmed = false;
+
+            float duration = _dialogueLineData != null ? _dialogueLineData.FadeOutDuration : 0.5f;
+            float time = 0f;
+
+            float startAlphaImage = _image ? _image.color.a : 1f;
+            float startAlphaText = _linkedText ? _linkedText.color.a : 1f;
+
+            while (time < duration)
+            {
+                float t = time / duration;
+                float alphaImage = Mathf.Lerp(startAlphaImage, 0f, t);
+                float alphaText = Mathf.Lerp(startAlphaText, 0f, t);
+
+                if (_image)
+                {
+                    var color = _image.color;
+                    _image.color = new Color(color.r, color.g, color.b, alphaImage);
+                }
+
+                if (_linkedText)
+                {
+                    var color = _linkedText.color;
+                    _linkedText.color = new Color(color.r, color.g, color.b, alphaText);
+                }
+
+                time += Time.deltaTime;
+                yield return null;
+            }
+
+            if (_image)
+                _image.color = new Color(_image.color.r, _image.color.g, _image.color.b, 0f);
+
+            if (_linkedText)
+                _linkedText.color = new Color(_linkedText.color.r, _linkedText.color.g, _linkedText.color.b, 0f);
         }
 
         public void ResetEffect()

--- a/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
+++ b/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
@@ -39,29 +39,24 @@ namespace MoonlitMixes.Dialogue.Effect
             _linkedText = text;
         }
 
-        public void ApplyEffect(SpeakerEffectType effectType)
+        public IEnumerator PlayEffect(SpeakerEffectType effectType)
         {
             switch (effectType)
             {
                 case SpeakerEffectType.Tremble:
-                    StartCoroutine(TrembleEffect());
+                    yield return StartCoroutine(TrembleEffect());
                     break;
-
                 case SpeakerEffectType.Jump:
-                    StartCoroutine(JumpEffect());
+                    yield return StartCoroutine(JumpEffect());
                     break;
-
                 case SpeakerEffectType.FadeIn:
-                    StartCoroutine(FadeInEffect());
+                    yield return StartCoroutine(FadeInEffect());
                     break;
-
                 case SpeakerEffectType.FadeOut:
-                    StartCoroutine(FadeOutEffect());
+                    yield return StartCoroutine(FadeOutEffect());
                     break;
-
                 default:
-                    Debug.LogWarning("Unknown effect type");
-                    break;
+                    yield break;
             }
         }
 

--- a/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
+++ b/Assets/_Core/Scripts/Dialogue/SpeakerEffect.cs
@@ -1,4 +1,4 @@
-using MoonlitMixes.Datas;
+ï»¿using MoonlitMixes.Datas;
 using System.Collections;
 using TMPro;
 using UnityEngine;
@@ -16,6 +16,7 @@ namespace MoonlitMixes.Dialogue.Effect
         private DialogueLineData _dialogueLineData;
         private bool _isDimmed = false;
 
+        public bool SkipEffectNow { get; set; } = false;
 
         private void Awake()
         {
@@ -41,6 +42,8 @@ namespace MoonlitMixes.Dialogue.Effect
 
         public IEnumerator PlayEffect(SpeakerEffectType effectType)
         {
+            SkipEffectNow = false;
+
             switch (effectType)
             {
                 case SpeakerEffectType.Tremble:
@@ -72,71 +75,70 @@ namespace MoonlitMixes.Dialogue.Effect
             Quaternion originalRotation = transform.rotation;
             Vector3 textOriginalPosition = _linkedText != null ? _linkedText.rectTransform.localPosition : Vector3.zero;
 
-            transform.localScale = new Vector3(1f, 1f, 1f);
+            transform.localScale = Vector3.one;
             if (_linkedText)
-            {
-                _linkedText.rectTransform.localScale = new Vector3(1f, 1f, 1f);
-            }
+                _linkedText.rectTransform.localScale = Vector3.one;
 
             float intensityX = _dialogueLineData.TrembleIntensityX;
             float intensityY = _dialogueLineData.TrembleIntensityY;
 
-            // Début du tremblement
+            // DÃ©but du tremblement
             for (int i = 0; i < 20; i++)
             {
-                // Applique une variation aléatoire à la position de l'image
+                if (SkipEffectNow) break;
+
+                // Applique une variation alÃ©atoire Ã  la position de l'image
                 Vector3 offset = new Vector3(Random.Range(-intensityX, intensityX), Random.Range(-intensityY, intensityY), 0);
                 transform.localPosition = originalPosition + offset;
 
-                // Applique un tremblement à la position du texte
+                // Applique un tremblement Ã  la position du texte
                 if (_linkedText)
                 {
-                    RectTransform textRect = _linkedText.rectTransform;
                     Vector3 textOffset = new Vector3(Random.Range(-intensityX, intensityX), Random.Range(-intensityY, intensityY), 0);
-                    textRect.localPosition = textOriginalPosition + textOffset;
+                    _linkedText.rectTransform.localPosition = textOriginalPosition + textOffset;
                 }
 
-                // Variation légère de la rotation de l'image pour un effet de tremblement
-                float trembleAmount = Random.Range(-5f, 5f);
-                transform.rotation = originalRotation * Quaternion.Euler(0, 0, trembleAmount);
+                // Variation lÃ©gÃ¨re de la rotation de l'image pour un effet de tremblement
+                transform.rotation = originalRotation * Quaternion.Euler(0, 0, Random.Range(-5f, 5f));
 
-                yield return new WaitForSeconds(0.05f);  // Pause avant le prochain tremblement
+                yield return new WaitForSeconds(0.05f);
             }
 
             transform.localPosition = originalPosition;
             transform.rotation = originalRotation;
 
             if (_linkedText)
-            {
                 _linkedText.rectTransform.localPosition = textOriginalPosition;
-            }
         }
 
         private IEnumerator JumpEffect()
         {
-            if (_image == null && _linkedText == null)
-                yield break;
+            if (_image == null && _linkedText == null) yield break;
 
             Vector3 originalPos = transform.localPosition;
             Vector3 textOriginalPos = _linkedText ? _linkedText.rectTransform.localPosition : Vector3.zero;
 
             for (int i = 0; i < 10; i++)
             {
-                Vector3 jump = new Vector3(0, 15f, 0);  // Saut de l'image
-                transform.localPosition = originalPos + jump;
+                if (SkipEffectNow) break;
 
+                Vector3 jump = new Vector3(0, 15f, 0);
+                transform.localPosition = originalPos + jump;
                 if (_linkedText)
                     _linkedText.rectTransform.localPosition = textOriginalPos + jump;
 
                 yield return new WaitForSeconds(0.1f);
 
                 transform.localPosition = originalPos;
-
                 if (_linkedText)
                     _linkedText.rectTransform.localPosition = textOriginalPos;
 
                 yield return new WaitForSeconds(0.1f);
             }
+
+            transform.localPosition = originalPos;
+            if (_linkedText)
+                _linkedText.rectTransform.localPosition = textOriginalPos;
         }
 
         public void DimEffect()
@@ -145,16 +147,14 @@ namespace MoonlitMixes.Dialogue.Effect
 
             if (_image != null)
             {
-                _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 0.5f); // Sprite semi-transparent
-
-                RectTransform rectTransform = _image.rectTransform;
-                rectTransform.sizeDelta = new Vector2(rectTransform.sizeDelta.x * 0.8f, rectTransform.sizeDelta.y * 0.8f);
+                _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 0.5f);
+                _image.rectTransform.sizeDelta *= 0.8f;
             }
 
             if (_linkedText != null)
             {
                 var textColor = _linkedText.color;
-                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 0.5f); // Texte semi-transparent
+                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 0.5f);
             }
         }
 
@@ -162,38 +162,30 @@ namespace MoonlitMixes.Dialogue.Effect
         {
             _isDimmed = false;
 
-            if (_image)
-            {
-                _image.color = _originalColor;
-                RectTransform rectTransform = _image.rectTransform;
-                rectTransform.sizeDelta = new Vector2(_originalScale.x * 300f, _originalScale.y * 300f);
-            }
-
+            if (_image) _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 0f);
             if (_linkedText)
-            {
-                var textColor = _linkedText.color;
-                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 0f);
-            }
+                _linkedText.color = new Color(_linkedText.color.r, _linkedText.color.g, _linkedText.color.b, 0f);
 
-            float duration = _dialogueLineData != null ? _dialogueLineData.FadeInDuration : 0.5f;
+            float duration = _dialogueLineData?.FadeInDuration ?? 0.5f;
             float time = 0f;
 
             while (time < duration)
             {
+                if (SkipEffectNow) break;
+
                 float t = time / duration;
-                float alphaImage = Mathf.Lerp(0f, 1f, t);
-                float alphaText = Mathf.Lerp(0f, 1f, t);
+                float alpha = Mathf.Lerp(0f, 1f, t);
 
                 if (_image)
                 {
                     var color = _image.color;
-                    _image.color = new Color(color.r, color.g, color.b, alphaImage);
+                    _image.color = new Color(color.r, color.g, color.b, alpha);
                 }
 
                 if (_linkedText)
                 {
                     var color = _linkedText.color;
-                    _linkedText.color = new Color(color.r, color.g, color.b, alphaText);
+                    _linkedText.color = new Color(color.r, color.g, color.b, alpha);
                 }
 
                 time += Time.deltaTime;
@@ -211,7 +203,7 @@ namespace MoonlitMixes.Dialogue.Effect
         {
             _isDimmed = false;
 
-            float duration = _dialogueLineData != null ? _dialogueLineData.FadeOutDuration : 0.5f;
+            float duration = _dialogueLineData?.FadeOutDuration ?? 0.5f;
             float time = 0f;
 
             float startAlphaImage = _image ? _image.color.a : 1f;
@@ -219,47 +211,42 @@ namespace MoonlitMixes.Dialogue.Effect
 
             while (time < duration)
             {
+                if (SkipEffectNow) break;
+
                 float t = time / duration;
-                float alphaImage = Mathf.Lerp(startAlphaImage, 0f, t);
-                float alphaText = Mathf.Lerp(startAlphaText, 0f, t);
+                float alpha = Mathf.Lerp(startAlphaImage, 0f, t);
 
                 if (_image)
                 {
                     var color = _image.color;
-                    _image.color = new Color(color.r, color.g, color.b, alphaImage);
+                    _image.color = new Color(color.r, color.g, color.b, alpha);
                 }
 
                 if (_linkedText)
                 {
                     var color = _linkedText.color;
-                    _linkedText.color = new Color(color.r, color.g, color.b, alphaText);
+                    _linkedText.color = new Color(color.r, color.g, color.b, alpha);
                 }
 
                 time += Time.deltaTime;
                 yield return null;
             }
-
-            if (_image)
-                _image.color = new Color(_image.color.r, _image.color.g, _image.color.b, 0f);
-
-            if (_linkedText)
-                _linkedText.color = new Color(_linkedText.color.r, _linkedText.color.g, _linkedText.color.b, 0f);
         }
 
         public void ResetEffect()
         {
+            SkipEffectNow = false;
+
             if (_image != null)
             {
-                _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 1f); // Sprite opaque
-
-                RectTransform rectTransform = _image.rectTransform;
-                rectTransform.sizeDelta = new Vector2(_originalScale.x * 300f, _originalScale.y * 300f);
+                _image.color = new Color(_originalColor.r, _originalColor.g, _originalColor.b, 1f);
+                _image.rectTransform.sizeDelta = new Vector2(_originalScale.x * 300f, _originalScale.y * 300f);
             }
 
             if (_linkedText != null)
             {
                 var textColor = _linkedText.color;
-                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 1f); // Texte opaque
+                _linkedText.color = new Color(textColor.r, textColor.g, textColor.b, 1f);
             }
         }
     }

--- a/Assets/_Core/Scripts/Inventory/DialogueLineData.cs
+++ b/Assets/_Core/Scripts/Inventory/DialogueLineData.cs
@@ -13,6 +13,12 @@ namespace MoonlitMixes.Datas
         [SerializeField, HideInInspector] private float _trembleIntensityX = 5f;
         [SerializeField, HideInInspector] private float _trembleIntensityY = 5f;
 
+        [SerializeField, Range(0.1f, 5f), HideInInspector] private float _fadeInDuration = 0.5f;
+        [SerializeField, Range(0.1f, 5f), HideInInspector] private float _fadeOutDuration = 0.5f;
+
+        public float FadeInDuration => _fadeInDuration;
+        public float FadeOutDuration => _fadeOutDuration;
+
         public string Text => _text;
         public int SpeakerIndex => _speakerIndex;
         public Sprite SpeakerSprite => _speakerSprite;
@@ -31,12 +37,15 @@ namespace MoonlitMixes.Datas
         }
 
         public bool IsTrembleEffect => _effect == SpeakerEffectType.Tremble;
+        public bool IsFadeEffect => _effect == SpeakerEffectType.FadeIn || _effect == SpeakerEffectType.FadeOut;
     }
 
     public enum SpeakerEffectType
     {
         None,
         Tremble,
-        Jump
+        Jump,
+        FadeIn,
+        FadeOut
     }
 }

--- a/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLine Begin 1.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLine Begin 1.asset
@@ -15,4 +15,8 @@ MonoBehaviour:
   _text: Bonjour, j'aimerai une potion s'il vous plait
   _speakerIndex: 1
   _speakerSprite: {fileID: 21300000, guid: 38d08d05f1cbdc54c8b16121bb77f2b0, type: 3}
-  _effect: 0
+  _effect: 4
+  _trembleIntensityX: 5
+  _trembleIntensityY: 5
+  _fadeInDuration: 0.5
+  _fadeOutDuration: 1.75

--- a/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLineBegin.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLineBegin.asset
@@ -15,6 +15,8 @@ MonoBehaviour:
   _text: Bonjour, qu'est ce que je peux faire pour vous ?
   _speakerIndex: 0
   _speakerSprite: {fileID: 21300000, guid: 16ff745b80a10804bb3f32a9dc8e4230, type: 3}
-  _effect: 1
+  _effect: 3
   _trembleIntensityX: 1
   _trembleIntensityY: 1
+  _fadeInDuration: 1.67
+  _fadeOutDuration: 1.33


### PR DESCRIPTION
### **Effets de speaker (`SpeakerEffectType`)**

#### 1. **FadeIn**

* L'élément (texte ou sprite du personnage) **apparaît progressivement**, en fondu.
* Le texte commence **seulement après** que l’effet soit complètement terminé.

#### 2. **FadeOut**

* L’élément **disparaît progressivement**, en fondu.
* Le texte est **entièrement affiché** avant que l’effet ne démarre.