### PR TITLE
Dev progess/change of the sale system

### DIFF
--- a/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
+++ b/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
@@ -1086,7 +1086,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.x
@@ -1094,7 +1094,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.x
@@ -1102,15 +1102,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 700
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1134,11 +1134,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 700
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1371,7 +1371,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.x
@@ -1379,7 +1379,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.x
@@ -1387,15 +1387,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 430
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1423,7 +1423,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2785,7 +2785,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.x
@@ -2793,7 +2793,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.x
@@ -2801,15 +2801,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1240
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2837,7 +2837,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -2992,7 +2992,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   potionResultListData: {fileID: 11400000, guid: 980e327af7488dd4987d76fa55ff98f8, type: 2}
-  _slotPrefab: {fileID: 7400195189864738404, guid: 27a0cdd4a9b9b8d4b95d93fba52acb54, type: 3}
+  _slotPrefab: {fileID: 7839139791226570139, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
   _slotContainer: {fileID: 2145729657}
   _specialButtonPrefab: {fileID: 7839139791226570139, guid: 5d1ff7d482672864d8596bd67b886ed2, type: 3}
 --- !u!1 &1531993378
@@ -3278,7 +3278,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.x
@@ -3286,7 +3286,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.x
@@ -3294,15 +3294,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 970
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3330,7 +3330,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4430,7 +4430,7 @@ MonoBehaviour:
   m_OverrideTileSize: 0
   m_TileSize: 256
   m_OverrideVoxelSize: 0
-  m_VoxelSize: 0.14999999
+  m_VoxelSize: 0.096666664
   m_MinRegionArea: 2
   m_NavMeshData: {fileID: 23800000, guid: 65c5adc19a47142468dc263eece5bfda, type: 2}
   m_BuildHeightMesh: 0
@@ -4605,7 +4605,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.x
@@ -4613,7 +4613,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.x
@@ -4621,15 +4621,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 170
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 160
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -135
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4657,7 +4657,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8861404396757583489, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
+++ b/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
@@ -932,7 +932,7 @@ PrefabInstance:
       objectReference: {fileID: 11400000, guid: 7df61e8daf7929d42904dd37fdcdc3b5, type: 2}
     - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: _requestPotionArray.Array.size
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: '_requestPotionArray.Array.data[0]'
@@ -945,7 +945,7 @@ PrefabInstance:
     - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: '_requestPotionArray.Array.data[2]'
       value: 
-      objectReference: {fileID: 11400000, guid: 94ac83b7aed3387418703cfa5e0afe46, type: 2}
+      objectReference: {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
     - target: {fileID: 9128046576808368923, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_Enabled
       value: 0
@@ -1979,6 +1979,14 @@ PrefabInstance:
       propertyPath: '_potionList.Array.data[1]'
       value: 
       objectReference: {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+    - target: {fileID: 8525346488732657459, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+      propertyPath: _requestPotionArray.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525346488732657459, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+      propertyPath: '_requestPotionArray.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3390,6 +3398,14 @@ PrefabInstance:
       propertyPath: '_potionList.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+    - target: {fileID: 8105294104795306671, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
+      propertyPath: _requestPotionArray.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105294104795306671, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
+      propertyPath: '_requestPotionArray.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
     - target: {fileID: 8354640808962684786, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_Name
       value: X Bot_001

--- a/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
+++ b/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
@@ -923,6 +923,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: _secondbeginDialogueData
+      value: 
+      objectReference: {fileID: 11400000, guid: d970d086f4820f84885e42783a6562c5, type: 2}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: '_potionList.Array.data[0]'
       value: 
       objectReference: {fileID: 11400000, guid: 7df61e8daf7929d42904dd37fdcdc3b5, type: 2}

--- a/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
+++ b/Assets/_Core/Scenes/ScenesTest/ST_Sales_system.unity
@@ -227,6 +227,11 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.0000001, y: 1.25, z: 0.010000002}
   m_Center: {x: -0.00000047683716, y: 0.625, z: -0.0049995193}
+--- !u!1 &84965240 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5624540124730411847, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+  m_PrefabInstance: {fileID: 1378853060}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &145157943
 GameObject:
   m_ObjectHideFlags: 0
@@ -656,6 +661,11 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 8354640808962684786, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
   m_PrefabInstance: {fileID: 1601430062}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &319540988 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
+  m_PrefabInstance: {fileID: 1601430062}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &412595380
 GameObject:
   m_ObjectHideFlags: 0
@@ -730,7 +740,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 
+  m_text: New Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -846,7 +856,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1759438255}
     m_Modifications:
     - target: {fileID: 2308735518983896891, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_Name
@@ -862,15 +872,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.1844225
+      value: 5.06318
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.34720993
+      value: 10.740228
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 9.74
+      value: -25.721907
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalRotation.w
@@ -878,15 +888,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -908,6 +918,30 @@ PrefabInstance:
       propertyPath: _waypointsParent
       value: 
       objectReference: {fileID: 1218735611}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: _potionList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: '_potionList.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 7df61e8daf7929d42904dd37fdcdc3b5, type: 2}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: _requestPotionArray.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: '_requestPotionArray.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: '_requestPotionArray.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+    - target: {fileID: 7561991305090039826, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+      propertyPath: '_requestPotionArray.Array.data[2]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 94ac83b7aed3387418703cfa5e0afe46, type: 2}
     - target: {fileID: 9128046576808368923, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
       propertyPath: m_Enabled
       value: 0
@@ -957,27 +991,31 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1925943512}
+    m_TransformParent: {fileID: 1807334163}
     m_Modifications:
     - target: {fileID: 3823381552549770213, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_Name
       value: PB_Prop_Registercash_proto_001
       objectReference: {fileID: 0}
+    - target: {fileID: 3823381552549770213, guid: a471d33651babee4ba28128c0c623066, type: 3}
+      propertyPath: m_TagString
+      value: Register
+      objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.84
+      value: 15.749577
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.7
+      value: 14.03694
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.779
+      value: -6.7104864
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 0.71748394
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalRotation.x
@@ -985,7 +1023,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: -0.6965751
       objectReference: {fileID: 0}
     - target: {fileID: 4486906770068007263, guid: a471d33651babee4ba28128c0c623066, type: 3}
       propertyPath: m_LocalRotation.z
@@ -1540,8 +1578,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 2.2878976, y: 0.5164499, z: 1.9810967}
-  m_Center: {x: 0.45289844, y: 0.25822496, z: 0.6905475}
+  m_Size: {x: 2.2878976, y: 2.270677, z: 0.649836}
+  m_Center: {x: 0.45289838, y: 1.1353385, z: 0.024916602}
 --- !u!114 &715053523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1554,7 +1592,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 981255906b9e247498bf98234493da47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _interactionButton: {fileID: 715053524}
+  _dayNightCycleInfo: {fileID: 11400000, guid: 51f631fcb88537044928d007237a09a5, type: 2}
 --- !u!114 &715053524
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1863,7 +1901,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1759438255}
     m_Modifications:
     - target: {fileID: 2485771309794994920, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_Name
@@ -1875,15 +1913,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.83
+      value: 3.0487576
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.005000353
+      value: 10.398018
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 7.0679817
+      value: -28.393925
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1891,15 +1929,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1925,6 +1963,18 @@ PrefabInstance:
       propertyPath: _waypointsParent
       value: 
       objectReference: {fileID: 1218735611}
+    - target: {fileID: 8525346488732657459, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+      propertyPath: _potionList.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525346488732657459, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+      propertyPath: '_potionList.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+    - target: {fileID: 8525346488732657459, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+      propertyPath: '_potionList.Array.data[1]'
+      value: 
+      objectReference: {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1933,6 +1983,11 @@ PrefabInstance:
 --- !u!1 &1117653901 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2308735518983896891, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
+  m_PrefabInstance: {fileID: 443888609}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1117653905 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3116937431705511297, guid: 1171a31f25843434c98ab27e4d2a2b97, type: 3}
   m_PrefabInstance: {fileID: 443888609}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1132598515
@@ -2405,7 +2460,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2016172447903645169, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_Height
-      value: 2
+      value: 1.6
       objectReference: {fileID: 0}
     - target: {fileID: 3601989135736639393, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2453,7 +2508,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_ActionEvents.Array.size
-      value: 21
+      value: 29
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_ActionEvents.Array.data[18].m_ActionId
@@ -2468,6 +2523,38 @@ PrefabInstance:
       value: b0ae578a-f3d1-45fc-bec8-768089fe53a6
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[21].m_ActionId
+      value: e6f246a9-c28b-42cf-9a91-9d2d542859fc
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[22].m_ActionId
+      value: d53f41a5-b2bd-4e75-a0de-dddad7a43124
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[23].m_ActionId
+      value: 0199fa42-5012-45f4-9ebb-bfabf0e1f60d
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[24].m_ActionId
+      value: c3dc5756-3dbc-410f-bde2-0b58057b6698
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[25].m_ActionId
+      value: 49253ea5-8010-4666-9fca-c5b89483921a
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[26].m_ActionId
+      value: 430d9fd0-03b9-4123-8ac3-ac337b708860
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[27].m_ActionId
+      value: cbea3ec9-4b1f-4f99-aa67-ccd3f82ffb1b
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[28].m_ActionId
+      value: fe59328c-bc52-48e9-80de-d9cb5ad94e1d
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_ActionEvents.Array.data[18].m_ActionName
       value: Player/OpenCloseCanvas
       objectReference: {fileID: 0}
@@ -2480,11 +2567,47 @@ PrefabInstance:
       value: Recipe/CloseRecipe
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[21].m_ActionName
+      value: 'Menu/Navigate[/Keyboard/w,/Keyboard/s,/Keyboard/a,/Keyboard/d]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[22].m_ActionName
+      value: 'Menu/Submit[/Keyboard/e]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[23].m_ActionName
+      value: 'Menu/Cancel[/Keyboard/q]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[24].m_ActionName
+      value: Menu/Chapter
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[25].m_ActionName
+      value: Menu/QuitMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[26].m_ActionName
+      value: 'ChangeScene/Navigate[/Keyboard/z,/Keyboard/w,/Keyboard/a,/Keyboard/d]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[27].m_ActionName
+      value: 'ChangeScene/Submit[/Keyboard/e]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[28].m_ActionName
+      value: 'ChangeScene/Cancel[/Keyboard/escape]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_ActionEvents.Array.data[18].m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
       propertyPath: m_ActionEvents.Array.data[19].m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      propertyPath: m_ActionEvents.Array.data[2].m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7040424696320952584, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
@@ -2525,21 +2648,42 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 6290198562764003013, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+    - {fileID: 6187662445069279546, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5624540124730411847, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1378853067}
   m_SourcePrefab: {fileID: 100100000, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
 --- !u!114 &1378853061 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7511533593464994434, guid: 210ce764b2243be4b8ebca07464c62ef, type: 3}
   m_PrefabInstance: {fileID: 1378853060}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 84965240}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ab0135a207c05a14a824ee45b45968b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1378853067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84965240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91bcffa169a27f4429132a3f2c07aaac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _interactionDistance: 1
+  _layerHitable:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  _dayNightCycleInfo: {fileID: 11400000, guid: 51f631fcb88537044928d007237a09a5, type: 2}
 --- !u!1 &1385745641
 GameObject:
   m_ObjectHideFlags: 0
@@ -2847,8 +2991,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3ca5572a77d4eb940a4ad991bce773b9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  potionResultListData: {fileID: 11400000, guid: 66dc7d06323c3ff4c8ba46dba43958bd, type: 2}
-  _slotPrefab: {fileID: 7839139791226570139, guid: e5c0acd6de2726c49b1e42e2b6040fe9, type: 3}
+  potionResultListData: {fileID: 11400000, guid: 980e327af7488dd4987d76fa55ff98f8, type: 2}
+  _slotPrefab: {fileID: 7400195189864738404, guid: 27a0cdd4a9b9b8d4b95d93fba52acb54, type: 3}
   _slotContainer: {fileID: 2145729657}
   _specialButtonPrefab: {fileID: 7839139791226570139, guid: 5d1ff7d482672864d8596bd67b886ed2, type: 3}
 --- !u!1 &1531993378
@@ -2890,7 +3034,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 
+  m_text: New Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3216,7 +3360,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1759438255}
     m_Modifications:
     - target: {fileID: 2983328154646775112, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_Enabled
@@ -3234,6 +3378,14 @@ PrefabInstance:
       propertyPath: _waypointsParent
       value: 
       objectReference: {fileID: 1218735611}
+    - target: {fileID: 8105294104795306671, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
+      propertyPath: _potionList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8105294104795306671, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
+      propertyPath: '_potionList.Array.data[0]'
+      value: 
+      objectReference: {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
     - target: {fileID: 8354640808962684786, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_Name
       value: X Bot_001
@@ -3244,15 +3396,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.1169443
+      value: 4.995702
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.005000353
+      value: 10.398018
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 7.0679817
+      value: -28.393925
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3260,15 +3412,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8699394417339117000, guid: 5ac3c76d3ced70c43a81facf48546bba, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3624,6 +3776,40 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1 &1759438254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1759438255}
+  m_Layer: 0
+  m_Name: Costumers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1759438255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1759438254}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.8787575, y: -10.393018, z: 35.461906}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1117653905}
+  - {fileID: 319540988}
+  - {fileID: 2133094894}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1794422394
 GameObject:
   m_ObjectHideFlags: 0
@@ -3699,6 +3885,40 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1794422394}
   m_CullTransparentMesh: 1
+--- !u!1 &1807334162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807334163}
+  m_Layer: 0
+  m_Name: Interact
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1807334163
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807334162}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -16.144562, y: -13.33694, z: 21.767746}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 492393877}
+  - {fileID: 7420402931515875012}
+  - {fileID: 7695237070727368301}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1925943511
 GameObject:
   m_ObjectHideFlags: 0
@@ -3730,10 +3950,7 @@ Transform:
   m_Children:
   - {fileID: 7300557517905413020}
   - {fileID: 8917990518551398599}
-  - {fileID: 7420402931515875012}
-  - {fileID: 7695237070727368301}
   - {fileID: 7316357864091485079}
-  - {fileID: 492393877}
   - {fileID: 1554370539893882039}
   - {fileID: 5483429415168159808}
   - {fileID: 7968099478212214411}
@@ -3940,6 +4157,11 @@ Transform:
 --- !u!1 &2133094890 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2485771309794994920, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
+  m_PrefabInstance: {fileID: 1052923920}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2133094894 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2969256966037205074, guid: 3659cf7e6f84c634f9f155d28e720e7e, type: 3}
   m_PrefabInstance: {fileID: 1052923920}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &2145729656
@@ -4679,23 +4901,23 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1925943512}
+    m_TransformParent: {fileID: 1807334163}
     m_Modifications:
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.392
+      value: 19.10183
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 13.33694
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -6.894
+      value: -2.6928463
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.01478477
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalRotation.x
@@ -4703,7 +4925,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.99989074
       objectReference: {fileID: 0}
     - target: {fileID: 1163043670999469828, guid: 3537d769c9edf3345bcb72edc038004f, type: 3}
       propertyPath: m_LocalRotation.z
@@ -4810,23 +5032,23 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1925943512}
+    m_TransformParent: {fileID: 1807334163}
     m_Modifications:
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3
+      value: 19.594433
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 13.33694
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3
+      value: -6.603117
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.01478477
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalRotation.x
@@ -4834,7 +5056,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.99989074
       objectReference: {fileID: 0}
     - target: {fileID: 5041126635304862164, guid: ced51bf66075b154c9fee64ffd86a43b, type: 3}
       propertyPath: m_LocalRotation.z
@@ -5146,13 +5368,12 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1746431154}
+  - {fileID: 1618054277}
   - {fileID: 2086097114}
   - {fileID: 1729164843}
   - {fileID: 2084169994}
   - {fileID: 412595381}
   - {fileID: 1378853060}
-  - {fileID: 1618054277}
+  - {fileID: 1807334163}
   - {fileID: 1218735611}
-  - {fileID: 443888609}
-  - {fileID: 1601430062}
-  - {fileID: 1052923920}
+  - {fileID: 1759438255}

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -118,7 +118,7 @@ namespace MoonlitMixes.Dialogue
                 return;
             }
 
-            // 👉 DIM DES AUTRES immédiatement
+            // DIM DES AUTRES immédiatement
             for (int i = 0; i < _spriteSpeakerEffects.Length; i++)
             {
                 if (i == speakerIndex) continue;

--- a/Assets/_Core/Scripts/PNJ/CustomerSpawner.cs
+++ b/Assets/_Core/Scripts/PNJ/CustomerSpawner.cs
@@ -16,7 +16,6 @@ namespace MoonlitMixes.AI.PNJ.Spawner
         [SerializeField] private float _timeBetweenSpawns = 2f;
         [SerializeField] private int _maxCustomers = 3;
         [SerializeField] private PlayerMovement _playerMovement;
-        [SerializeField] private ScriptablePotionResultEvent _scriptablePotionResultEvent;
 
         private int _currentPNJIndex = 0;
         private bool _isSpawning = false;
@@ -49,7 +48,6 @@ namespace MoonlitMixes.AI.PNJ.Spawner
                     pnjStateMachine.OnDespawn += OnPNJDespawned;
                 }
 
-                _scriptablePotionResultEvent.OnPotionResultEvent(pnjStateMachine.pnjData.RequestPotionList.PotionResults[_currentPNJIndex]);
                 _currentPNJIndex++;
             }
         }

--- a/Assets/_Core/Scripts/PNJ/PNJData.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJData.cs
@@ -1,28 +1,123 @@
-using MoonlitMixes.AI.PNJ.StateMachine;
 using MoonlitMixes.Datas;
 using MoonlitMixes.Potion;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 
-namespace MoonlitMixes.AI.PNJ
+[Serializable]
+public class PNJData
 {
-    public class PNJData
+    [SerializeField] private GameObject pnjGameObject;
+    [SerializeField] private NavMeshAgent agent;
+    [SerializeField] private Animator animator;
+
+    [SerializeField] private List<Transform> waypoints;
+    [SerializeField] private float dialogueDuration;
+
+    [SerializeField] private PotionResult[] requestPotionArray;
+    [SerializeField] private List<PotionResult> potionValidList;
+
+    [SerializeField] private DialogueData beginDialogueData;
+    [SerializeField] private DialogueData secondbeginDialogueData;
+    [SerializeField] private DialogueData successDialogueData;
+    [SerializeField] private DialogueData failureDialogueData;
+    [SerializeField] private DialogueData noPotionDialogueData;
+
+    [SerializeField] private PotionResult selectedPotionResult;
+    [SerializeField] private int currentPotionIndex;
+    [SerializeField] private int failedAttempt;
+
+    public Action OnDespawn { get; set; }
+    public Action<PotionResult> OnPotionSelected { get; set; }
+
+    public GameObject PnjGameObject
     {
-        public GameObject pnjGameObject;
-        public NavMeshAgent agent;
-        public Animator animator;
-        public List<Transform> waypoints;
-        public float dialogueDuration;
-        public PotionResult[] requestPotionArray;
-        public List<PotionResult> potionValidList;
-        public PotionResult selectedPotionResult;
-        public DialogueData beginDialogueData;
-        public DialogueData successDialogueData;
-        public DialogueData failureDialogueData;
-        public DialogueData noPotionDialogueData;
-        public DialogueData secondbeginDialogueData;
-        public System.Action OnDespawn;
-        public System.Action<PotionResult> OnPotionSelected;
+        get => pnjGameObject;
+        set => pnjGameObject = value;
+    }
+
+    public NavMeshAgent Agent
+    {
+        get => agent;
+        set => agent = value;
+    }
+
+    public Animator Animator
+    {
+        get => animator;
+        set => animator = value;
+    }
+
+    public List<Transform> Waypoints
+    {
+        get => waypoints;
+        set => waypoints = value;
+    }
+
+    public float DialogueDuration
+    {
+        get => dialogueDuration;
+        set => dialogueDuration = value;
+    }
+
+    public PotionResult[] RequestPotionArray
+    {
+        get => requestPotionArray;
+        set => requestPotionArray = value;
+    }
+
+    public List<PotionResult> PotionValidList
+    {
+        get => potionValidList;
+        set => potionValidList = value;
+    }
+
+    public DialogueData BeginDialogueData
+    {
+        get => beginDialogueData;
+        set => beginDialogueData = value;
+    }
+
+    public DialogueData SecondBeginDialogueData
+    {
+        get => secondbeginDialogueData;
+        set => secondbeginDialogueData = value;
+    }
+
+    public DialogueData SuccessDialogueData
+    {
+        get => successDialogueData;
+        set => successDialogueData = value;
+    }
+
+    public DialogueData FailureDialogueData
+    {
+        get => failureDialogueData;
+        set => failureDialogueData = value;
+    }
+
+    public DialogueData NoPotionDialogueData
+    {
+        get => noPotionDialogueData;
+        set => noPotionDialogueData = value;
+    }
+
+    public PotionResult SelectedPotionResult
+    {
+        get => selectedPotionResult;
+        set => selectedPotionResult = value;
+    }
+
+    public int CurrentPotionIndex
+    {
+        get => currentPotionIndex;
+        set => currentPotionIndex = value;
+    }
+
+    public int FailedAttempt
+    {
+        get => failedAttempt;
+        set => failedAttempt = value;
     }
 }

--- a/Assets/_Core/Scripts/PNJ/PNJData.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJData.cs
@@ -9,26 +9,19 @@ namespace MoonlitMixes.AI.PNJ
 {
     public class PNJData
     {
-        public GameObject PNJGameObject { get; }
-        public NavMeshAgent Agent { get; }
-        public Animator Animator { get; }
-        public List<Transform> Waypoints { get; }
-        public float DialogueDuration { get; }
-        public int CurrentWaypointIndex { get; set; } = 0;
-
-        public PotionListData RequestPotionList { get; }
-        public PotionResult RequestPotion { get; }
-        public PNJStateMachine StateMachine { get; }
-
-        public PNJData(GameObject pnj, NavMeshAgent agent, Animator animator, List<Transform> waypoints, float dialogueDuration, PotionListData potionList, PNJStateMachine stateMachine)
-        {
-            PNJGameObject = pnj;
-            Agent = agent;
-            Animator = animator;
-            Waypoints = waypoints;
-            DialogueDuration = dialogueDuration;
-            RequestPotionList = potionList;
-            StateMachine = stateMachine;
-        }
+        public GameObject pnjGameObject;
+        public NavMeshAgent agent;
+        public Animator animator;
+        public List<Transform> waypoints;
+        public float dialogueDuration;
+        public PotionResult[] requestPotionArray;
+        public List<PotionResult> potionValidList;
+        public PotionResult selectedPotionResult;
+        public DialogueData beginDialogueData;
+        public DialogueData successDialogueData;
+        public DialogueData failureDialogueData;
+        public DialogueData noPotionDialogueData;
+        public System.Action OnDespawn;
+        public System.Action<PotionResult> OnPotionSelected;
     }
 }

--- a/Assets/_Core/Scripts/PNJ/PNJData.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJData.cs
@@ -21,6 +21,7 @@ namespace MoonlitMixes.AI.PNJ
         public DialogueData successDialogueData;
         public DialogueData failureDialogueData;
         public DialogueData noPotionDialogueData;
+        public DialogueData secondbeginDialogueData;
         public System.Action OnDespawn;
         public System.Action<PotionResult> OnPotionSelected;
     }

--- a/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
@@ -23,6 +23,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
         [SerializeField] private DialogueData _successDialogueData;
         [SerializeField] private DialogueData _failureDialogueData;
         [SerializeField] private DialogueData _noPotionDialogueData;
+        [SerializeField] private DialogueData _secondbeginDialogueData;
 
         private NavMeshAgent _agent;
         private Animator _animator;
@@ -58,6 +59,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
                 failureDialogueData = _failureDialogueData,
                 noPotionDialogueData = _noPotionDialogueData,
                 successDialogueData = _successDialogueData,
+                secondbeginDialogueData = _secondbeginDialogueData,
                 OnDespawn = InvokeOnDespawn,
                 OnPotionSelected = SetSelectedPotion,
             };

--- a/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
@@ -1,8 +1,10 @@
 using MoonlitMixes.AI.PNJ.StateMachine.States;
 using MoonlitMixes.Datas;
+using MoonlitMixes.Potion;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.AI;
-using System.Collections.Generic;
 
 namespace MoonlitMixes.AI.PNJ.StateMachine
 {
@@ -10,17 +12,10 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
     {
         public event System.Action OnDespawn;
 
-        public string SelectedPotionName { get; private set; }
-        public int FailedAttempts => _failedAttempts;
-        public DialogueData BeginDialogueData => _beginDialogueData;
-        public DialogueData SuccessDialogueData => _successDialogueData;
-        public DialogueData FailureDialogueData => _failureDialogueData;
-        public DialogueData NoPotionDialogueData => _noPotionDialogueData;
-
         [Header("Configuration")]
         [SerializeField] private Transform _waypointsParent;
         [SerializeField] private float _dialogueDuration = 3f;
-        [SerializeField] private PotionListData _potionList;
+        [SerializeField] private PotionResult[] _requestPotionArray;
 
         [Header("Dialogue Settings")]
         [SerializeField] private DialogueData _beginDialogueData;
@@ -31,12 +26,8 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
         private NavMeshAgent _agent;
         private Animator _animator;
         private PNJData _pnjData;
-        public PNJData pnjData
-        {
-            get => _pnjData;
-        }
         private IPNJState _currentState;
-        private int _failedAttempts = 0;
+        private List<PotionResult> _potionValidList = new();
 
         private void Awake()
         {
@@ -47,14 +38,28 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
 
         public void Initialize()
         {
-            List<Transform> waypoints = new List<Transform>();
+            List<Transform> waypoints = new();
             foreach (Transform child in _waypointsParent)
             {
                 waypoints.Add(child);
             }
 
-            _pnjData = new PNJData(gameObject, _agent, _animator, waypoints, _dialogueDuration, _potionList, this);
-
+            _pnjData = new PNJData
+            {
+                pnjGameObject = gameObject,
+                agent = _agent,
+                animator = _animator,
+                waypoints = waypoints,
+                dialogueDuration = _dialogueDuration,
+                requestPotionArray = _requestPotionArray,
+                potionValidList = _potionValidList,
+                beginDialogueData = _beginDialogueData,
+                failureDialogueData = _failureDialogueData,
+                noPotionDialogueData = _noPotionDialogueData,
+                successDialogueData = _successDialogueData,
+                OnDespawn = InvokeOnDespawn,
+                OnPotionSelected = SetSelectedPotion,
+            };
 
             SetState(new SpawnState());
         }
@@ -83,19 +88,25 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
             OnDespawn?.Invoke();
         }
 
-        public void SetSelectedPotion(string potionName)
+        public void SetSelectedPotion(PotionResult potionResultSelected)
         {
-            SelectedPotionName = potionName;
-        }
+            IEnumerable<PotionResult> result = _requestPotionArray.Except(_potionValidList);
 
-        public void IncrementFailedAttempts()
-        {
-            _failedAttempts++;
-        }
+            bool isPotionValid = false;
 
-        public void ResetFailedAttempts()
-        {
-            _failedAttempts = 0;
+            foreach (PotionResult potionResultItem in result)
+            {
+                if (potionResultItem == potionResultSelected)
+                {
+                    isPotionValid = true;
+                    break;
+                }
+            }
+
+            if (isPotionValid)
+            {
+                _potionValidList.Add(potionResultSelected);
+            }
         }
 
         private void DisablePNJ()

--- a/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
@@ -3,7 +3,6 @@ using MoonlitMixes.Datas;
 using MoonlitMixes.Dialogue;
 using MoonlitMixes.Potion;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -48,20 +47,20 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
 
             _pnjData = new PNJData
             {
-                pnjGameObject = gameObject,
-                agent = _agent,
-                animator = _animator,
-                waypoints = waypoints,
-                dialogueDuration = _dialogueDuration,
-                requestPotionArray = _requestPotionArray,
-                potionValidList = _potionValidList,
-                beginDialogueData = _beginDialogueData,
-                failureDialogueData = _failureDialogueData,
-                noPotionDialogueData = _noPotionDialogueData,
-                successDialogueData = _successDialogueData,
-                secondbeginDialogueData = _secondbeginDialogueData,
+                PnjGameObject = gameObject,
+                Agent = _agent,
+                Animator = _animator,
+                Waypoints = waypoints,
+                RequestPotionArray = _requestPotionArray,
+                PotionValidList = _potionValidList,
+                BeginDialogueData = _beginDialogueData,
+                FailureDialogueData = _failureDialogueData,
+                NoPotionDialogueData = _noPotionDialogueData,
+                SuccessDialogueData = _successDialogueData,
+                SecondBeginDialogueData = _secondbeginDialogueData,
                 OnDespawn = InvokeOnDespawn,
                 OnPotionSelected = SetSelectedPotion,
+                CurrentPotionIndex = 0
             };
 
             SetState(new SpawnState());
@@ -99,23 +98,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
 
         public void SetSelectedPotion(PotionResult potionResultSelected)
         {
-            IEnumerable<PotionResult> result = _requestPotionArray.Except(_potionValidList);
-
-            bool isPotionValid = false;
-
-            foreach (PotionResult potionResultItem in result)
-            {
-                if (potionResultItem == potionResultSelected)
-                {
-                    isPotionValid = true;
-                    break;
-                }
-            }
-
-            if (isPotionValid)
-            {
-                _potionValidList.Add(potionResultSelected);
-            }
+            _pnjData.SelectedPotionResult = potionResultSelected;
         }
 
         private void DisablePNJ()

--- a/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
+++ b/Assets/_Core/Scripts/PNJ/PNJStateMachine.cs
@@ -1,5 +1,6 @@
-using MoonlitMixes.AI.PNJ.StateMachine.States;
+﻿using MoonlitMixes.AI.PNJ.StateMachine.States;
 using MoonlitMixes.Datas;
+using MoonlitMixes.Dialogue;
 using MoonlitMixes.Potion;
 using System.Collections.Generic;
 using System.Linq;
@@ -62,6 +63,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine
             };
 
             SetState(new SpawnState());
+
+            PotionChoiceController controller = FindFirstObjectByType<PotionChoiceController>();
+            if (controller != null)
+            {
+                controller.SetRequestedPotions(_requestPotionArray);
+            }
         }
 
         private void Update()

--- a/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
@@ -12,7 +12,6 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
         private bool _isDialogueFinished = false;
         private bool _isSuccess = false;
         private bool _isNoPotion = false;
-        private int _failedAttempt = 0;
 
         public void EnterState(PNJData data)
         {
@@ -20,18 +19,13 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             _potionPriceCalculated = Object.FindFirstObjectByType<PotionPriceCalculate>();
             _potionChoiceController = Object.FindFirstObjectByType<PotionChoiceController>();
 
-            data.agent.isStopped = true;
-            data.animator.SetBool("isWalking", false);
-
-            if (_potionChoiceController != null)
-            {
-                data.selectedPotionResult = _potionChoiceController.SelectedPotionResult;
-            }
+            data.Agent.isStopped = true;
+            data.Animator.SetBool("isWalking", false);
 
             int potionPrice = 100;
-            if (_potionInventory != null && data.selectedPotionResult != null)
+            if (_potionInventory != null && data.SelectedPotionResult != null)
             {
-                PotionResult selectedPotion = _potionInventory.PotionList.Find(p => p == data.selectedPotionResult);
+                PotionResult selectedPotion = _potionInventory.PotionList.Find(p => p == data.SelectedPotionResult);
                 if (selectedPotion != null)
                 {
                     potionPrice = selectedPotion.Price;
@@ -40,41 +34,32 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
             DialogueController.OnDialogueFinished += OnDialogueEnd;
 
-            if (data.selectedPotionResult == null)
+            if (data.SelectedPotionResult == null)
             {
                 _isNoPotion = true;
-                ResetFailedAttempts();
+                data.FailedAttempt = 0; // Reset if no potion selected
                 _potionPriceCalculated?.CalculatePotionPrice(0, 0);
-                DialogueController.Instance.StartDialogue(data.noPotionDialogueData);
+                DialogueController.Instance.StartDialogue(data.NoPotionDialogueData);
             }
             else if (IsSelectedPotionValid(data))
             {
                 _isSuccess = true;
-                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, _failedAttempt);
-                DialogueController.Instance.StartDialogue(data.successDialogueData);
+                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, data.FailedAttempt);
+                DialogueController.Instance.StartDialogue(data.SuccessDialogueData);
             }
             else
             {
-                IncrementFailedAttempts();
-                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, _failedAttempt);
-                DialogueController.Instance.StartDialogue(data.failureDialogueData);
+                data.FailedAttempt++;
+                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, data.FailedAttempt);
+                DialogueController.Instance.StartDialogue(data.FailureDialogueData);
             }
         }
 
         private bool IsSelectedPotionValid(PNJData data)
         {
-            return data.selectedPotionResult != null &&
-                   System.Array.Exists(data.requestPotionArray, p => p == data.selectedPotionResult);
-        }
-
-        private void IncrementFailedAttempts()
-        {
-            _failedAttempt++;
-        }
-
-        private void ResetFailedAttempts()
-        {
-            _failedAttempt = 0;
+            return data.SelectedPotionResult != null &&
+                   data.CurrentPotionIndex < data.RequestPotionArray.Length &&
+                   data.SelectedPotionResult == data.RequestPotionArray[data.CurrentPotionIndex];
         }
 
         public IPNJState UpdateState(PNJData data)
@@ -85,18 +70,20 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
                 if (_isSuccess)
                 {
-                    data.potionValidList.Add(data.selectedPotionResult);
+                    data.PotionValidList.Add(data.SelectedPotionResult);
+                    data.CurrentPotionIndex++;
+                    data.FailedAttempt = 0; // Reset on success
 
-                    if (data.potionValidList.Count < data.requestPotionArray.Length)
+                    if (data.PotionValidList.Count < data.RequestPotionArray.Length)
                         return new SecondDialogueState();
                     else
                         return new MoveToStartState();
                 }
 
-                if (_isNoPotion || _failedAttempt >= 3)
-                    return new MoveToStartState(); // Trop d’erreurs ou aucune potion
+                if (_isNoPotion || data.FailedAttempt >= 3)
+                    return new MoveToStartState();
 
-                return new SecondDialogueState(); // On revient avec un nouveau dialogue d’intro
+                return new ChoosePotionState(); // Retry if not max failed
             }
 
             return null;
@@ -104,7 +91,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void ExitState(PNJData data)
         {
-            data.agent.isStopped = false;
+            data.Agent.isStopped = false;
             DialogueController.OnDialogueFinished -= OnDialogueEnd;
         }
 

--- a/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
@@ -83,22 +83,20 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             {
                 DialogueController.OnDialogueFinished -= OnDialogueEnd;
 
-                if (_isSuccess || _isNoPotion)
+                if (_isSuccess)
                 {
-                    ResetFailedAttempts();
-                    return new MoveToStartState();
-                }
-                else
-                {
-                    if (_failedAttempt < 3)
-                    {
-                        return new ChoosePotionState();
-                    }
+                    data.potionValidList.Add(data.selectedPotionResult);
+
+                    if (data.potionValidList.Count < data.requestPotionArray.Length)
+                        return new SecondDialogueState();
                     else
-                    {
                         return new MoveToStartState();
-                    }
                 }
+
+                if (_isNoPotion || _failedAttempt >= 3)
+                    return new MoveToStartState(); // Trop d’erreurs ou aucune potion
+
+                return new SecondDialogueState(); // On revient avec un nouveau dialogue d’intro
             }
 
             return null;

--- a/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
@@ -23,8 +23,13 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             data.agent.isStopped = true;
             data.animator.SetBool("isWalking", false);
 
+            if (_potionChoiceController != null)
+            {
+                data.selectedPotionResult = _potionChoiceController.SelectedPotionResult;
+            }
+
             int potionPrice = 100;
-            if (_potionInventory != null)
+            if (_potionInventory != null && data.selectedPotionResult != null)
             {
                 PotionResult selectedPotion = _potionInventory.PotionList.Find(p => p == data.selectedPotionResult);
                 if (selectedPotion != null)
@@ -35,19 +40,19 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
             DialogueController.OnDialogueFinished += OnDialogueEnd;
 
-            if (IsSelectedPotionValid(data))
+            if (data.selectedPotionResult == null)
+            {
+                _isNoPotion = true;
+                ResetFailedAttempts();
+                _potionPriceCalculated?.CalculatePotionPrice(0, 0);
+                DialogueController.Instance.StartDialogue(data.noPotionDialogueData);
+            }
+            else if (IsSelectedPotionValid(data))
             {
                 _isSuccess = true;
                 _potionPriceCalculated?.CalculatePotionPrice(potionPrice, _failedAttempt);
                 DialogueController.Instance.StartDialogue(data.successDialogueData);
             }
-            //else if (/*IsNullOrEmpty = si c'est 0 valid*/data.selectedPotionResult)
-            //{
-            //    _isNoPotion = true;
-            //    ResetFailedAttempts();
-            //    _potionPriceCalculated?.CalculatePotionPrice(0, 0);
-            //    DialogueController.Instance.StartDialogue(data.noPotionDialogueData);
-            //}
             else
             {
                 IncrementFailedAttempts();
@@ -58,13 +63,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         private bool IsSelectedPotionValid(PNJData data)
         {
-            return System.Array.Exists(data.requestPotionArray, p => p == data.selectedPotionResult);
+            return data.selectedPotionResult != null &&
+                   System.Array.Exists(data.requestPotionArray, p => p == data.selectedPotionResult);
         }
-
 
         private void IncrementFailedAttempts()
         {
-
             _failedAttempt++;
         }
 

--- a/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoiceDialogueState.cs
@@ -12,6 +12,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
         private bool _isDialogueFinished = false;
         private bool _isSuccess = false;
         private bool _isNoPotion = false;
+        private int _failedAttempt = 0;
 
         public void EnterState(PNJData data)
         {
@@ -19,13 +20,13 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             _potionPriceCalculated = Object.FindFirstObjectByType<PotionPriceCalculate>();
             _potionChoiceController = Object.FindFirstObjectByType<PotionChoiceController>();
 
-            data.Agent.isStopped = true;
-            data.Animator.SetBool("isWalking", false);
+            data.agent.isStopped = true;
+            data.animator.SetBool("isWalking", false);
 
             int potionPrice = 100;
             if (_potionInventory != null)
             {
-                PotionResult selectedPotion = _potionInventory.PotionList.Find(p => p.Recipe.RecipeName == data.StateMachine.SelectedPotionName);
+                PotionResult selectedPotion = _potionInventory.PotionList.Find(p => p == data.selectedPotionResult);
                 if (selectedPotion != null)
                 {
                     potionPrice = selectedPotion.Price;
@@ -34,25 +35,42 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
             DialogueController.OnDialogueFinished += OnDialogueEnd;
 
-            if (_potionChoiceController.SelectedPotionName == data.StateMachine.SelectedPotionName)
+            if (IsSelectedPotionValid(data))
             {
                 _isSuccess = true;
-                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, data.StateMachine.FailedAttempts);
-                DialogueController.Instance.StartDialogue(data.StateMachine.SuccessDialogueData);
+                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, _failedAttempt);
+                DialogueController.Instance.StartDialogue(data.successDialogueData);
             }
-            else if (string.IsNullOrEmpty(data.StateMachine.SelectedPotionName))
-            {
-                _isNoPotion = true;
-                data.StateMachine.ResetFailedAttempts();
-                _potionPriceCalculated?.CalculatePotionPrice(0, 0);
-                DialogueController.Instance.StartDialogue(data.StateMachine.NoPotionDialogueData);
-            }
+            //else if (/*IsNullOrEmpty = si c'est 0 valid*/data.selectedPotionResult)
+            //{
+            //    _isNoPotion = true;
+            //    ResetFailedAttempts();
+            //    _potionPriceCalculated?.CalculatePotionPrice(0, 0);
+            //    DialogueController.Instance.StartDialogue(data.noPotionDialogueData);
+            //}
             else
             {
-                data.StateMachine.IncrementFailedAttempts();
-                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, data.StateMachine.FailedAttempts);
-                DialogueController.Instance.StartDialogue(data.StateMachine.FailureDialogueData);
+                IncrementFailedAttempts();
+                _potionPriceCalculated?.CalculatePotionPrice(potionPrice, _failedAttempt);
+                DialogueController.Instance.StartDialogue(data.failureDialogueData);
             }
+        }
+
+        private bool IsSelectedPotionValid(PNJData data)
+        {
+            return System.Array.Exists(data.requestPotionArray, p => p == data.selectedPotionResult);
+        }
+
+
+        private void IncrementFailedAttempts()
+        {
+
+            _failedAttempt++;
+        }
+
+        private void ResetFailedAttempts()
+        {
+            _failedAttempt = 0;
         }
 
         public IPNJState UpdateState(PNJData data)
@@ -63,12 +81,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
                 if (_isSuccess || _isNoPotion)
                 {
-                    data.StateMachine.ResetFailedAttempts();
+                    ResetFailedAttempts();
                     return new MoveToStartState();
                 }
                 else
                 {
-                    if (data.StateMachine.FailedAttempts < 3)
+                    if (_failedAttempt < 3)
                     {
                         return new ChoosePotionState();
                     }
@@ -84,7 +102,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void ExitState(PNJData data)
         {
-            data.Agent.isStopped = false;
+            data.agent.isStopped = false;
             DialogueController.OnDialogueFinished -= OnDialogueEnd;
         }
 

--- a/Assets/_Core/Scripts/PNJ/State/ChoosePotionState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoosePotionState.cs
@@ -1,4 +1,5 @@
 using MoonlitMixes.Dialogue;
+using MoonlitMixes.Potion;
 using UnityEngine;
 
 namespace MoonlitMixes.AI.PNJ.StateMachine.States
@@ -7,7 +8,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
     {
         private PotionChoiceController _potionChoice;
         private bool _isWaitingForChoice = true;
-        private string _potionNameSelected;
+        private PotionResult _potionResultSelected;
 
         public void EnterState(PNJData data)
         {
@@ -29,12 +30,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
         {
             if (!_isWaitingForChoice)
             {
-                data.StateMachine.SetSelectedPotion(_potionNameSelected);
+                data.OnPotionSelected?.Invoke(_potionResultSelected);
 
                 return new ChoiceDialogueState();
             }
 
-            return null; 
+            return null;
         }
 
         public void ExitState(PNJData data)
@@ -42,11 +43,11 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             PotionChoiceController.OnPotionChoiceSelected -= OnPotionSelected;
         }
 
-        private void OnPotionSelected(string potionName)
+        private void OnPotionSelected(PotionResult potionResult)
         {
-            _potionNameSelected = potionName;
+            _potionResultSelected = potionResult;
             _isWaitingForChoice = false;
-            Debug.Log("Potion choisie: " + potionName);
+            Debug.Log("Potion choisie: " + potionResult);
         }
     }
 }

--- a/Assets/_Core/Scripts/PNJ/State/ChoosePotionState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/ChoosePotionState.cs
@@ -1,4 +1,4 @@
-using MoonlitMixes.Dialogue;
+﻿using MoonlitMixes.Dialogue;
 using MoonlitMixes.Potion;
 using UnityEngine;
 
@@ -16,12 +16,14 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
             if (_potionChoice != null)
             {
-                _potionChoice.ShowPotionChoices();
+                _potionChoice.ShowPotionChoices(data.CurrentPotionIndex);
+
                 _isWaitingForChoice = true;
                 PotionChoiceController.OnPotionChoiceSelected += OnPotionSelected;
             }
             else
             {
+                Debug.LogWarning("[ChoosePotionState] Aucun PotionChoiceController trouvé.");
                 _isWaitingForChoice = false;
             }
         }
@@ -31,7 +33,6 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
             if (!_isWaitingForChoice)
             {
                 data.OnPotionSelected?.Invoke(_potionResultSelected);
-
                 return new ChoiceDialogueState();
             }
 
@@ -47,7 +48,8 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
         {
             _potionResultSelected = potionResult;
             _isWaitingForChoice = false;
-            Debug.Log("Potion choisie: " + potionResult);
+
+            Debug.Log($"[ChoosePotionState] Potion choisie par le joueur : {potionResult?.Recipe?.RecipeName ?? "null"}");
         }
     }
 }

--- a/Assets/_Core/Scripts/PNJ/State/DespawnState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/DespawnState.cs
@@ -4,8 +4,8 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
     {
         public void EnterState(PNJData data)
         {
-            data.StateMachine.InvokeOnDespawn();
-            data.PNJGameObject.SetActive(false);
+            data.OnDespawn?.Invoke();
+            data.pnjGameObject.SetActive(false);
         }
 
         public IPNJState UpdateState(PNJData data)

--- a/Assets/_Core/Scripts/PNJ/State/DespawnState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/DespawnState.cs
@@ -5,7 +5,7 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
         public void EnterState(PNJData data)
         {
             data.OnDespawn?.Invoke();
-            data.pnjGameObject.SetActive(false);
+            data.PnjGameObject.SetActive(false);
         }
 
         public IPNJState UpdateState(PNJData data)

--- a/Assets/_Core/Scripts/PNJ/State/DialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/DialogueState.cs
@@ -8,12 +8,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.agent.isStopped = true;
-            data.animator.SetBool("isWalking", false);
+            data.Agent.isStopped = true;
+            data.Animator.SetBool("isWalking", false);
 
-            if (DialogueController.Instance != null && data.beginDialogueData != null)
+            if (DialogueController.Instance != null && data.BeginDialogueData != null)
             {
-                DialogueController.Instance.StartDialogue(data.beginDialogueData);
+                DialogueController.Instance.StartDialogue(data.BeginDialogueData);
                 DialogueController.OnDialogueFinished += OnDialogueEnd;
             }
             else

--- a/Assets/_Core/Scripts/PNJ/State/DialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/DialogueState.cs
@@ -1,5 +1,4 @@
 using MoonlitMixes.Dialogue;
-using UnityEngine;
 
 namespace MoonlitMixes.AI.PNJ.StateMachine.States
 {
@@ -9,12 +8,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.Agent.isStopped = true;
-            data.Animator.SetBool("isWalking", false);
+            data.agent.isStopped = true;
+            data.animator.SetBool("isWalking", false);
 
-            if (DialogueController.Instance != null && data.StateMachine.BeginDialogueData != null)
+            if (DialogueController.Instance != null && data.beginDialogueData != null)
             {
-                DialogueController.Instance.StartDialogue(data.StateMachine.BeginDialogueData);
+                DialogueController.Instance.StartDialogue(data.beginDialogueData);
                 DialogueController.OnDialogueFinished += OnDialogueEnd;
             }
             else

--- a/Assets/_Core/Scripts/PNJ/State/MoveToEndState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/MoveToEndState.cs
@@ -8,17 +8,17 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.animator.SetBool("isWalking", true);
-            data.agent.SetDestination(data.waypoints[data.waypoints.Count - 1].position);
+            data.Animator.SetBool("isWalking", true);
+            data.Agent.SetDestination(data.Waypoints[data.Waypoints.Count - 1].position);
         }
 
         public IPNJState UpdateState(PNJData data)
         {
-            if (!_hasArrived && !data.agent.pathPending && data.agent.remainingDistance <= data.agent.stoppingDistance)
+            if (!_hasArrived && !data.Agent.pathPending && data.Agent.remainingDistance <= data.Agent.stoppingDistance)
             {
                 _hasArrived = true;
-                data.animator.SetBool("isWalking", false);
-                data.agent.updateRotation = false;
+                data.Animator.SetBool("isWalking", false);
+                data.Agent.updateRotation = false;
 
                 RotateLeft(data);
 
@@ -30,12 +30,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void ExitState(PNJData data)
         {
-            data.agent.updateRotation = true;
+            data.Agent.updateRotation = true;
         }
 
         private void RotateLeft(PNJData data)
         {
-            data.pnjGameObject.transform.rotation = Quaternion.Euler(0, -90, 0);
+            data.PnjGameObject.transform.rotation = Quaternion.Euler(0, -90, 0);
         }
     }
 }

--- a/Assets/_Core/Scripts/PNJ/State/MoveToEndState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/MoveToEndState.cs
@@ -8,17 +8,17 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.Animator.SetBool("isWalking", true);
-            data.Agent.SetDestination(data.Waypoints[data.Waypoints.Count - 1].position);
+            data.animator.SetBool("isWalking", true);
+            data.agent.SetDestination(data.waypoints[data.waypoints.Count - 1].position);
         }
 
         public IPNJState UpdateState(PNJData data)
         {
-            if (!_hasArrived && !data.Agent.pathPending && data.Agent.remainingDistance <= data.Agent.stoppingDistance)
+            if (!_hasArrived && !data.agent.pathPending && data.agent.remainingDistance <= data.agent.stoppingDistance)
             {
                 _hasArrived = true;
-                data.Animator.SetBool("isWalking", false);
-                data.Agent.updateRotation = false;
+                data.animator.SetBool("isWalking", false);
+                data.agent.updateRotation = false;
 
                 RotateLeft(data);
 
@@ -30,12 +30,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void ExitState(PNJData data)
         {
-            data.Agent.updateRotation = true;
+            data.agent.updateRotation = true;
         }
 
         private void RotateLeft(PNJData data)
         {
-            data.PNJGameObject.transform.rotation = Quaternion.Euler(0, -90, 0);
+            data.pnjGameObject.transform.rotation = Quaternion.Euler(0, -90, 0);
         }
     }
 }

--- a/Assets/_Core/Scripts/PNJ/State/MoveToStartState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/MoveToStartState.cs
@@ -6,16 +6,16 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.agent.SetDestination(data.waypoints[0].position);
-            data.animator.SetBool("isWalking", true);
+            data.Agent.SetDestination(data.Waypoints[0].position);
+            data.Animator.SetBool("isWalking", true);
         }
 
         public IPNJState UpdateState(PNJData data)
         {
-            if (!_hasArrived && !data.agent.pathPending && data.agent.remainingDistance <= data.agent.stoppingDistance)
+            if (!_hasArrived && !data.Agent.pathPending && data.Agent.remainingDistance <= data.Agent.stoppingDistance)
             {
                 _hasArrived = true;
-                data.animator.SetBool("isWalking", false);
+                data.Animator.SetBool("isWalking", false);
 
                 return new DespawnState();
             }

--- a/Assets/_Core/Scripts/PNJ/State/MoveToStartState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/MoveToStartState.cs
@@ -6,16 +6,16 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.Agent.SetDestination(data.Waypoints[0].position);
-            data.Animator.SetBool("isWalking", true);
+            data.agent.SetDestination(data.waypoints[0].position);
+            data.animator.SetBool("isWalking", true);
         }
 
         public IPNJState UpdateState(PNJData data)
         {
-            if (!_hasArrived && !data.Agent.pathPending && data.Agent.remainingDistance <= data.Agent.stoppingDistance)
+            if (!_hasArrived && !data.agent.pathPending && data.agent.remainingDistance <= data.agent.stoppingDistance)
             {
                 _hasArrived = true;
-                data.Animator.SetBool("isWalking", false);
+                data.animator.SetBool("isWalking", false);
 
                 return new DespawnState();
             }

--- a/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using MoonlitMixes.Dialogue;
+
+namespace MoonlitMixes.AI.PNJ.StateMachine.States
+{
+    public class SecondDialogueState : IPNJState
+    {
+        private bool _dialogueFinished = false;
+
+        public void EnterState(PNJData data)
+        {
+            data.agent.isStopped = true;
+            data.animator.SetBool("isWalking", false);
+
+            if (DialogueController.Instance != null && data.secondbeginDialogueData != null)
+            {
+                DialogueController.Instance.StartDialogue(data.secondbeginDialogueData);
+                DialogueController.OnDialogueFinished += OnDialogueEnd;
+            }
+            else
+            {
+                _dialogueFinished = true;
+            }
+        }
+
+        public IPNJState UpdateState(PNJData data)
+        {
+            if (_dialogueFinished)
+            {
+                DialogueController.OnDialogueFinished -= OnDialogueEnd;
+                return new ChoosePotionState();
+            }
+
+            return null;
+        }
+
+        public void ExitState(PNJData data) { }
+
+        private void OnDialogueEnd()
+        {
+            _dialogueFinished = true;
+        }
+    }
+}

--- a/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using MoonlitMixes.Dialogue;
 
 namespace MoonlitMixes.AI.PNJ.StateMachine.States
@@ -9,12 +8,12 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
 
         public void EnterState(PNJData data)
         {
-            data.agent.isStopped = true;
-            data.animator.SetBool("isWalking", false);
+            data.Agent.isStopped = true;
+            data.Animator.SetBool("isWalking", false);
 
-            if (DialogueController.Instance != null && data.secondbeginDialogueData != null)
+            if (DialogueController.Instance != null && data.SecondBeginDialogueData != null)
             {
-                DialogueController.Instance.StartDialogue(data.secondbeginDialogueData);
+                DialogueController.Instance.StartDialogue(data.SecondBeginDialogueData);
                 DialogueController.OnDialogueFinished += OnDialogueEnd;
             }
             else

--- a/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs.meta
+++ b/Assets/_Core/Scripts/PNJ/State/SecondDialogueState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d53b73b3b26628a48b6ae0a040cbadc1

--- a/Assets/_Core/Scripts/PNJ/State/SpawnState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/SpawnState.cs
@@ -4,8 +4,8 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
     {
         public void EnterState(PNJData data)
         {
-            data.Agent.enabled = true;
-            data.Animator.enabled = true;
+            data.agent.enabled = true;
+            data.animator.enabled = true;
         }
 
         public IPNJState UpdateState(PNJData data)

--- a/Assets/_Core/Scripts/PNJ/State/SpawnState.cs
+++ b/Assets/_Core/Scripts/PNJ/State/SpawnState.cs
@@ -4,8 +4,8 @@ namespace MoonlitMixes.AI.PNJ.StateMachine.States
     {
         public void EnterState(PNJData data)
         {
-            data.agent.enabled = true;
-            data.animator.enabled = true;
+            data.Agent.enabled = true;
+            data.Animator.enabled = true;
         }
 
         public IPNJState UpdateState(PNJData data)

--- a/Assets/_Core/Scripts/Potion/PotionInventory.cs
+++ b/Assets/_Core/Scripts/Potion/PotionInventory.cs
@@ -1,10 +1,8 @@
 using MoonlitMixes.Datas;
 using MoonlitMixes.Dialogue;
-using MoonlitMixes.Inputs;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
@@ -12,25 +10,25 @@ namespace MoonlitMixes.Potion
 {
     public class PotionInventory : MonoBehaviour
     {
-        [SerializeField] private PotionListData _potionResultListData;
+        [SerializeField] private PotionListData potionResultListData;
         [SerializeField] private GameObject _slotPrefab;
         [SerializeField] private Transform _slotContainer;
         [SerializeField] private GameObject _specialButtonPrefab;
 
-        private string noPotionName = "No Potion";
+        private readonly string _noPotionName = "No Potion";
         private PotionChoiceController _potionChoiceController;
         private bool _isSelectionInProgress = false;
         private List<Button> _potionButtons = new List<Button>();
 
-        public List<PotionResult> PotionList => _potionResultListData.PotionResults;
+        public List<PotionResult> PotionList => potionResultListData.PotionResults;
 
         private void Start()
         {
-            if(SceneManager.GetActiveScene().name == "S_Labo")
+            if (SceneManager.GetActiveScene().name == "S_Labo")
             {
                 return;
             }
-            
+
             _potionChoiceController = FindFirstObjectByType<PotionChoiceController>();
 
             if (_potionChoiceController == null)
@@ -72,7 +70,6 @@ namespace MoonlitMixes.Potion
                 PotionResult potion = PotionList[i];
                 nameText.text = potion.Recipe.RecipeName;
                 potionImage.sprite = potion.Recipe.PotionSprite;
-                potionImage.preserveAspect = true;
 
                 Button btn = newSlot.GetComponent<Button>();
                 _potionButtons.Add(btn);
@@ -81,7 +78,7 @@ namespace MoonlitMixes.Potion
 
             GameObject specialButton = Instantiate(_specialButtonPrefab, _slotContainer);
             TextMeshProUGUI specialNameText = specialButton.GetComponentInChildren<TextMeshProUGUI>();
-            specialNameText.text = noPotionName;
+            specialNameText.text = _noPotionName;
 
             Button specialBtn = specialButton.GetComponent<Button>();
             _potionButtons.Add(specialBtn);
@@ -91,16 +88,6 @@ namespace MoonlitMixes.Potion
             Button cancelButtonNoPotion = confirmationPanelNoPotion.transform.Find("CancelButton").GetComponent<Button>();
 
             specialBtn.onClick.AddListener(() => OnNoPotionButtonClicked(null, confirmationPanelNoPotion, confirmButtonNoPotion, cancelButtonNoPotion, specialBtn));
-            if (_potionButtons.Count > 0)
-            {
-                EventSystem.current.SetSelectedGameObject(_potionButtons[0].gameObject);
-            }
-            else
-            {
-                EventSystem.current.SetSelectedGameObject(specialButton);
-            }
-
-            InputManager.Instance.SwitchActionMap("UI");
         }
 
         private void OnPotionButtonClicked(PotionResult potion, GameObject confirmationPanel, Button confirmButton, Button cancelButton, Button potionButton)
@@ -114,7 +101,6 @@ namespace MoonlitMixes.Potion
 
             potionButton.interactable = false;
             confirmationPanel.SetActive(true);
-            EventSystem.current.SetSelectedGameObject(confirmationPanel.gameObject.transform.GetChild(0).gameObject);
 
             confirmButton.onClick.RemoveAllListeners();
             confirmButton.onClick.AddListener(() => ConfirmPotionChoice(potion, confirmationPanel));
@@ -130,7 +116,6 @@ namespace MoonlitMixes.Potion
 
             potionButton.interactable = false;
             confirmationPanel.SetActive(true);
-            EventSystem.current.SetSelectedGameObject(confirmationPanel.gameObject.transform.GetChild(0).gameObject);
 
             confirmButton.onClick.RemoveAllListeners();
             confirmButton.onClick.AddListener(() => ConfirmPotionChoice(null, confirmationPanel));
@@ -145,13 +130,13 @@ namespace MoonlitMixes.Potion
             {
                 if (_potionChoiceController != null)
                 {
-                    _potionChoiceController.SelectPotion(potion.Recipe.RecipeName);
+                    _potionChoiceController.SelectPotion(potion);
                     RemovePotionFromList(potion.Recipe.RecipeName);
                 }
             }
             else
             {
-                _potionChoiceController.SelectPotion("");
+                _potionChoiceController.SelectPotion(null);
                 Debug.Log("Aucune potion s�lectionn�e (No Potion).");
             }
 
@@ -168,7 +153,6 @@ namespace MoonlitMixes.Potion
             potionButton.interactable = true;
             confirmationPanel.SetActive(false);
             TogglePotionButtons(true);
-            EventSystem.current.SetSelectedGameObject(potionButton.gameObject);
         }
 
         private void RemovePotionFromList(string potionName)

--- a/Assets/_Core/Scripts/SalesSystem/CloseOrOpenShop.cs
+++ b/Assets/_Core/Scripts/SalesSystem/CloseOrOpenShop.cs
@@ -14,13 +14,13 @@ namespace MoonlitMixes.AI.PNJ
 
         public void OnToggleShop()
         {
-            if (_dayNightCycleInfo.ActualTimePhase == 2)
-            {
+            //if (_dayNightCycleInfo.ActualTimePhase == 0)
+            //{
                 OnShopToggled?.Invoke(true);
                 CustomerSpawner.RequestSpawning();
                 OnShopUIShouldDeactivate?.Invoke();
                 _dayNightCycleInfo.ActualTimePhase++;
-            }
+            //}
         }
     }
 }

--- a/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
+++ b/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
@@ -10,9 +10,9 @@ namespace MoonlitMixes.Dialogue
         [SerializeField] private GameObject _potionChoicePanel;
         [SerializeField] private PotionInventory _potionInventory;
 
-        private Dictionary<string, int> _potionPrices = new Dictionary<string, int>();
+        private PotionResult[] _requestedPotions;
+        private Dictionary<string, int> _potionPrices = new();
         private PotionPriceCalculate _potionPriceCalculated;
-
 
         private PotionResult _selectedPotionResult;
         public PotionResult SelectedPotionResult => _selectedPotionResult;
@@ -29,26 +29,37 @@ namespace MoonlitMixes.Dialogue
             _potionChoicePanel.SetActive(false);
         }
 
+        public void SetRequestedPotions(PotionResult[] requestedPotions)
+        {
+            _requestedPotions = requestedPotions;
+        }
+
         public void ShowPotionChoices()
         {
             _potionChoicePanel.SetActive(true);
 
-            if (_potionInventory.PotionList.Count > 0)
+            if (_requestedPotions != null && _requestedPotions.Length > 0)
             {
-                _selectedPotionResult = _potionInventory.PotionList[0];
-                Debug.Log($"Potion choisie par le PNJ : {_selectedPotionResult}");
+                _selectedPotionResult = _requestedPotions[0]; // 💡 Choix manuel depuis l’inspecteur
+                Debug.Log($"Potion assignée au PNJ : {_selectedPotionResult}");
 
                 if (_potionPrices.TryGetValue(_selectedPotionResult.Recipe.RecipeName, out int price))
                 {
-                    Debug.Log($"Potion confirm�e: {_selectedPotionResult}, Prix: {price}");
+                    Debug.Log($"Potion confirmée: {_selectedPotionResult}, Prix: {price}");
                     _potionPrices.Remove(_selectedPotionResult.Recipe.RecipeName);
 
                     if (_potionPriceCalculated != null)
                     {
                         _potionPriceCalculated.SetSelectedPotionPrice(price);
                     }
-                    _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _potionInventory.PotionList[0].Price;
+
+                    _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _selectedPotionResult.Price;
                 }
+            }
+            else
+            {
+                Debug.LogWarning("Aucune potion assignée au PNJ.");
+                _selectedPotionResult = null;
             }
 
             _potionInventory.UpdatePotionCanvas();

--- a/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
+++ b/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
@@ -9,26 +9,15 @@ namespace MoonlitMixes.Dialogue
     {
         [SerializeField] private GameObject _potionChoicePanel;
         [SerializeField] private PotionInventory _potionInventory;
-        [SerializeField] private ScriptablePotionResultEvent _scriptablePotionResultEvent;
 
         private Dictionary<string, int> _potionPrices = new Dictionary<string, int>();
         private PotionPriceCalculate _potionPriceCalculated;
 
 
-        private string _selectedPotionName;
-        public string SelectedPotionName => _selectedPotionName;
+        private PotionResult _selectedPotionResult;
+        public PotionResult SelectedPotionResult => _selectedPotionResult;
 
-        public static event Action<string> OnPotionChoiceSelected;
-
-        private void OnEnable()
-        {
-            _scriptablePotionResultEvent.OnPotionResultEvent += SetSelectedPotion;
-        }
-
-        private void OnDisable()
-        {
-            _scriptablePotionResultEvent.OnPotionResultEvent -= SetSelectedPotion;
-        }
+        public static event Action<PotionResult> OnPotionChoiceSelected;
 
         private void Awake()
         {
@@ -46,42 +35,38 @@ namespace MoonlitMixes.Dialogue
 
             if (_potionInventory.PotionList.Count > 0)
             {
-                Debug.Log($"Potion choisie par le PNJ : {_selectedPotionName}");
+                _selectedPotionResult = _potionInventory.PotionList[0];
+                Debug.Log($"Potion choisie par le PNJ : {_selectedPotionResult}");
 
-                if (_potionPrices.TryGetValue(_selectedPotionName, out int price))
+                if (_potionPrices.TryGetValue(_selectedPotionResult.Recipe.RecipeName, out int price))
                 {
-                    Debug.Log($"Potion confirm�e: {_selectedPotionName}, Prix: {price}");
-                    _potionPrices.Remove(_selectedPotionName);
+                    Debug.Log($"Potion confirm�e: {_selectedPotionResult}, Prix: {price}");
+                    _potionPrices.Remove(_selectedPotionResult.Recipe.RecipeName);
 
                     if (_potionPriceCalculated != null)
                     {
                         _potionPriceCalculated.SetSelectedPotionPrice(price);
                     }
-                    _potionPrices[_selectedPotionName] = _potionInventory.PotionList[0].Price;
+                    _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _potionInventory.PotionList[0].Price;
                 }
             }
 
             _potionInventory.UpdatePotionCanvas();
         }
 
-        public void SelectPotion(string potionName)
+        public void SelectPotion(PotionResult potionResult)
         {
-            if (_selectedPotionName == potionName)
+            if (_selectedPotionResult == potionResult)
             {
                 Debug.Log("Bonne potion choisie !");
             }
             else
             {
-                Debug.Log(string.IsNullOrEmpty(potionName) ? "Pas de potion choisie !" : "Mauvaise potion, essayez encore !");
+                Debug.Log(potionResult == null ? "Pas de potion choisie !" : "Mauvaise potion, essayez encore !");
             }
 
-            OnPotionChoiceSelected?.Invoke(potionName);
+            OnPotionChoiceSelected?.Invoke(potionResult);
             _potionChoicePanel.SetActive(false);
-        }
-
-        private void SetSelectedPotion(PotionResult potionResult)
-        {
-            _selectedPotionName = potionResult.Recipe.RecipeName;
         }
     }
 }

--- a/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
+++ b/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
@@ -40,7 +40,7 @@ namespace MoonlitMixes.Dialogue
 
             if (_requestedPotions != null && _requestedPotions.Length > 0)
             {
-                _selectedPotionResult = _requestedPotions[0]; // 💡 Choix manuel depuis l’inspecteur
+                _selectedPotionResult = _requestedPotions[0];
                 Debug.Log($"Potion assignée au PNJ : {_selectedPotionResult}");
 
                 if (_potionPrices.TryGetValue(_selectedPotionResult.Recipe.RecipeName, out int price))
@@ -48,11 +48,7 @@ namespace MoonlitMixes.Dialogue
                     Debug.Log($"Potion confirmée: {_selectedPotionResult}, Prix: {price}");
                     _potionPrices.Remove(_selectedPotionResult.Recipe.RecipeName);
 
-                    if (_potionPriceCalculated != null)
-                    {
-                        _potionPriceCalculated.SetSelectedPotionPrice(price);
-                    }
-
+                    _potionPriceCalculated?.SetSelectedPotionPrice(price);
                     _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _selectedPotionResult.Price;
                 }
             }
@@ -67,14 +63,9 @@ namespace MoonlitMixes.Dialogue
 
         public void SelectPotion(PotionResult potionResult)
         {
-            if (_selectedPotionResult == potionResult)
-            {
-                Debug.Log("Bonne potion choisie !");
-            }
-            else
-            {
-                Debug.Log(potionResult == null ? "Pas de potion choisie !" : "Mauvaise potion, essayez encore !");
-            }
+            _selectedPotionResult = potionResult;
+
+            Debug.Log($"Potion sélectionnée : {(potionResult != null ? potionResult.Recipe.RecipeName : "aucune")}");
 
             OnPotionChoiceSelected?.Invoke(potionResult);
             _potionChoicePanel.SetActive(false);

--- a/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
+++ b/Assets/_Core/Scripts/SalesSystem/PotionChoiceController.cs
@@ -34,38 +34,53 @@ namespace MoonlitMixes.Dialogue
             _requestedPotions = requestedPotions;
         }
 
-        public void ShowPotionChoices()
+        /// <summary>
+        /// Affiche la bonne potion demandée par le client selon l'index courant.
+        /// </summary>
+        /// <param name="currentPotionIndex">Index de la potion demandée</param>
+        public void ShowPotionChoices(int currentPotionIndex)
         {
             _potionChoicePanel.SetActive(true);
 
-            if (_requestedPotions != null && _requestedPotions.Length > 0)
+            if (_requestedPotions != null && _requestedPotions.Length > currentPotionIndex)
             {
-                _selectedPotionResult = _requestedPotions[0];
-                Debug.Log($"Potion assignée au PNJ : {_selectedPotionResult}");
+                _selectedPotionResult = _requestedPotions[currentPotionIndex];
 
+                Debug.Log($"[PNJ] Potion demandée (étape {currentPotionIndex + 1}) : {_selectedPotionResult.Recipe.RecipeName}, Prix : {_selectedPotionResult.Price}");
+
+                // Enregistrer ou recalculer le prix si nécessaire
                 if (_potionPrices.TryGetValue(_selectedPotionResult.Recipe.RecipeName, out int price))
                 {
-                    Debug.Log($"Potion confirmée: {_selectedPotionResult}, Prix: {price}");
                     _potionPrices.Remove(_selectedPotionResult.Recipe.RecipeName);
-
-                    _potionPriceCalculated?.SetSelectedPotionPrice(price);
-                    _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _selectedPotionResult.Price;
                 }
+
+                _potionPrices[_selectedPotionResult.Recipe.RecipeName] = _selectedPotionResult.Price;
+                _potionPriceCalculated?.SetSelectedPotionPrice(_selectedPotionResult.Price);
             }
             else
             {
-                Debug.LogWarning("Aucune potion assignée au PNJ.");
+                Debug.LogWarning("[PNJ] Aucune potion disponible à cet index.");
                 _selectedPotionResult = null;
             }
 
             _potionInventory.UpdatePotionCanvas();
         }
 
+        /// <summary>
+        /// Appelé lorsque le joueur sélectionne une potion via l'UI.
+        /// </summary>
         public void SelectPotion(PotionResult potionResult)
         {
             _selectedPotionResult = potionResult;
 
-            Debug.Log($"Potion sélectionnée : {(potionResult != null ? potionResult.Recipe.RecipeName : "aucune")}");
+            if (potionResult != null)
+            {
+                Debug.Log($"[Joueur] Potion sélectionnée : {potionResult.Recipe.RecipeName}, Prix : {potionResult.Price}");
+            }
+            else
+            {
+                Debug.LogWarning("Aucune potion sélectionnée.");
+            }
 
             OnPotionChoiceSelected?.Invoke(potionResult);
             _potionChoicePanel.SetActive(false);

--- a/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLine Begin 1.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLine Begin 1.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _text: Bonjour, j'aimerai une potion s'il vous plait
   _speakerIndex: 1
   _speakerSprite: {fileID: 21300000, guid: 38d08d05f1cbdc54c8b16121bb77f2b0, type: 3}
-  _effect: 4
+  _effect: 0
   _trembleIntensityX: 5
   _trembleIntensityY: 5
   _fadeInDuration: 0.5

--- a/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLineBegin.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/BeginDialogueTest/NewLineBegin.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   _text: Bonjour, qu'est ce que je peux faire pour vous ?
   _speakerIndex: 0
   _speakerSprite: {fileID: 21300000, guid: 16ff745b80a10804bb3f32a9dc8e4230, type: 3}
-  _effect: 3
+  _effect: 0
   _trembleIntensityX: 1
   _trembleIntensityY: 1
   _fadeInDuration: 1.67

--- a/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/NoPotionDialogueTest/NoPotionNewLineTest.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialoguePNJTest/NoPotionDialogueTest/NoPotionNewLineTest.asset
@@ -12,7 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dba3b00ee53286a41b49d6b26b9c3c5b, type: 3}
   m_Name: NoPotionNewLineTest
   m_EditorClassIdentifier: 
-  _text: Tu n'as pas fait pas potion !? Quel honte !
+  _text: Tu n'as pas fait de potion !? Quel honte !
   _speakerIndex: 1
   _speakerSprite: {fileID: 21300000, guid: 38d08d05f1cbdc54c8b16121bb77f2b0, type: 3}
   _effect: 0
+  _trembleIntensityX: 5
+  _trembleIntensityY: 5
+  _fadeInDuration: 0.5
+  _fadeOutDuration: 0.5

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/DialogueSecondPotion.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/DialogueSecondPotion.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15ff58079d32d074a9ccb2aebff5a198, type: 3}
+  m_Name: DialogueSecondPotion
+  m_EditorClassIdentifier: 
+  _lines:
+  - {fileID: 11400000, guid: 7fb2b9f2db7f6e547896e4f2a34f8881, type: 2}
+  - {fileID: 11400000, guid: b5dfb8aa0e8926a4193c22aef9b26836, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/DialogueSecondPotion.asset.meta
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/DialogueSecondPotion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d970d086f4820f84885e42783a6562c5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line.meta
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dff2b384cce7bc844bee6960ebd56411
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dba3b00ee53286a41b49d6b26b9c3c5b, type: 3}
+  m_Name: SecondDialogueLineData
+  m_EditorClassIdentifier: 
+  _text: "J'aimerai une deuxi\xE8me potion svp "
+  _speakerIndex: 1
+  _speakerSprite: {fileID: 21300000, guid: 38d08d05f1cbdc54c8b16121bb77f2b0, type: 3}
+  _effect: 0
+  _trembleIntensityX: 5
+  _trembleIntensityY: 5
+  _fadeInDuration: 0.5
+  _fadeOutDuration: 0.5

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData.asset.meta
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fb2b9f2db7f6e547896e4f2a34f8881
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData1.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData1.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dba3b00ee53286a41b49d6b26b9c3c5b, type: 3}
+  m_Name: SecondDialogueLineData1
+  m_EditorClassIdentifier: 
+  _text: oh ok !
+  _speakerIndex: 0
+  _speakerSprite: {fileID: 21300000, guid: 16ff745b80a10804bb3f32a9dc8e4230, type: 3}
+  _effect: 0
+  _trembleIntensityX: 5
+  _trembleIntensityY: 5
+  _fadeInDuration: 0.5
+  _fadeOutDuration: 0.5

--- a/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData1.asset.meta
+++ b/Assets/_Core/Scripts/ScriptableObjects/DialogueTest/Line/SecondDialogueLineData1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5dfb8aa0e8926a4193c22aef9b26836
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
@@ -20,10 +20,13 @@ MonoBehaviour:
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
@@ -15,17 +15,12 @@ MonoBehaviour:
   potionResults:
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
@@ -12,4 +12,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e6fbb15bd61b78e48ac1cb4030251edc, type: 3}
   m_Name: PotionListDataPlayer
   m_EditorClassIdentifier: 
-  potionResults: []
+  potionResults:
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
+  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
@@ -14,8 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   potionResults:
   - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
@@ -25,3 +23,13 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/PotionListDataPlayer.asset
@@ -13,10 +13,6 @@ MonoBehaviour:
   m_Name: PotionListDataPlayer
   m_EditorClassIdentifier: 
   potionResults:
-  - {fileID: 11400000, guid: bbb2fc66460d12f41b21174c5a48d6d6, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
-  - {fileID: 11400000, guid: ea23395171f5fcb48aef7abf38d3a7e4, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
@@ -24,6 +20,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
   - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 47597921d13ab014895c5365b3251669, type: 2}
+  - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
   - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
   - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}
   - {fileID: 11400000, guid: 5f09096f77f5ebb45a582f1066a5d620, type: 2}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -4,7 +4,6 @@
 TagManager:
   serializedVersion: 3
   tags:
-  - Chest
   - Register
   layers:
   - Default
@@ -19,8 +18,8 @@ TagManager:
   - Inventory
   - Player
   - DoorScenes
-  - PickableItems
-  - Register
+  - 
+  - 
   - 
   - 
   - 


### PR DESCRIPTION
### Change of Sale System

Corrige le comportement erroné où le système utilisait toujours la première potion demandée (`_requestedPotions[0]`), au lieu de suivre l’ordre réel des potions attendues par le PNJ.

---

#### Changement de logique principale

* Les potions demandées par le PNJ sont désormais directement liées via l'inspecteur (`_requestPotionArray`) dans `PNJStateMachine`, ce qui rend la configuration plus claire et modulaire.
* La potion sélectionnée provient désormais directement de la liste des potions que le client souhaite, en utilisant l’index courant (`CurrentPotionIndex`), ce qui garantit que la bonne potion est affichée et validée à chaque étape.

---

#### `PotionChoiceController.cs`

* Ajout d’une surcharge de méthode `ShowPotionChoices(int potionIndex)`

  * Permet d’afficher la potion réellement attendue par le PNJ à une étape donnée (`CurrentPotionIndex`)
  * Évite de toujours prendre la première potion de la liste
* Ajout de logs explicites pour identifier quelle potion est demandée (nom et prix)
* Gestion sécurisée des erreurs d’index ou de données nulles
* Conservation de l'ancienne logique de sélection via `SelectPotion`

#### `ChoosePotionState.cs`

* Appel corrigé à `ShowPotionChoices(data.CurrentPotionIndex)` au lieu de la méthode sans paramètre

  * Cela permet d'afficher uniquement la potion demandée à cette étape précise
* Stockage correct de la potion sélectionnée par le joueur (`_potionResultSelected`)
* Nettoyage des logs pour rendre les informations plus explicites
* Ajout d’un message d’erreur si `PotionChoiceController` est introuvable

---

### Résultat attendu

* Le PNJ affiche maintenant la potion qu’il veut à chaque étape, dans le bon ordre
* Le joueur voit et peut sélectionner la potion correcte à livrer
* La sélection ne repose plus sur un comportement codé en dur, mais sur une configuration flexible et claire via l’inspecteur