### PR TITLE
Dev progess/auto transfer inventory on death

### DIFF
--- a/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
@@ -212852,6 +212852,7 @@ GameObject:
   - component: {fileID: 9009538453256599291}
   - component: {fileID: 6359275890681738510}
   - component: {fileID: 6359275890681738515}
+  - component: {fileID: 9009538453256599292}
   m_Layer: 12
   m_Name: Item_Chest
   m_TagString: Chest
@@ -213340,6 +213341,20 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.60272354, y: 0.58252317, z: 0.480989}
   m_Center: {x: -0.010720763, y: 0.28535122, z: -0.0035936073}
+--- !u!114 &9009538453256599292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7951906854285963691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc4e2ae547e5caf409e411ca720397e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerInventory: {fileID: 11400000, guid: cc39ff8a71f4c194d97487b527970f72, type: 2}
+  _chestInventory: {fileID: 11400000, guid: c434fad0bf085194da8dbbfaaee7df69, type: 2}
 --- !u!1 &9127037407492232817
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Core/Scripts/Health/PlayerHealth.cs
+++ b/Assets/_Core/Scripts/Health/PlayerHealth.cs
@@ -1,8 +1,8 @@
-using System;
-using MoonlitMixes.Player;
-using UnityEngine;
 using MoonlitMixes.Animation;
-using MoonlitMixes.Inputs;
+using MoonlitMixes.Events;
+using MoonlitMixes.Player;
+using System;
+using UnityEngine;
 using UnityEngine.InputSystem;
 
 namespace MoonlitMixes.Health
@@ -89,6 +89,8 @@ namespace MoonlitMixes.Health
                 _isDead = true;
                 _animationExplorationManager.Death();
                 GetComponent<PlayerInput>().DeactivateInput();
+
+                PlayerDeathEventDispatcher.TriggerDeath();
             }
 
             healthBarScriptableInt.SendHealthAmount(_currentHealth / _maxHealth);

--- a/Assets/_Core/Scripts/Inventory/InventoryTransferBootstrapper.cs
+++ b/Assets/_Core/Scripts/Inventory/InventoryTransferBootstrapper.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using MoonlitMixes.Datas;
+using MoonlitMixes.Item;
+
+namespace MoonlitMixes.Boot
+{
+    public class InventoryTransferBootstrapper : MonoBehaviour
+    {
+        [SerializeField] private InventoryData _playerInventory;
+        [SerializeField] private InventoryData _chestInventory;
+
+        private InventoryTransferOnDeathHandler _transferHandler;
+
+        private void Awake()
+        {
+            _transferHandler = new InventoryTransferOnDeathHandler(_playerInventory, _chestInventory);
+        }
+
+        private void OnDestroy()
+        {
+            _transferHandler.Dispose();
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Inventory/InventoryTransferBootstrapper.cs.meta
+++ b/Assets/_Core/Scripts/Inventory/InventoryTransferBootstrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc4e2ae547e5caf409e411ca720397e7

--- a/Assets/_Core/Scripts/Inventory/InventoryTransferOnDeathHandler.cs
+++ b/Assets/_Core/Scripts/Inventory/InventoryTransferOnDeathHandler.cs
@@ -1,0 +1,39 @@
+﻿using MoonlitMixes.Datas;
+using MoonlitMixes.Events;
+
+namespace MoonlitMixes.Item
+{
+    public class InventoryTransferOnDeathHandler
+    {
+        private readonly InventoryData _playerInventory;
+        private readonly InventoryData _chestInventory;
+
+        public InventoryTransferOnDeathHandler(InventoryData playerInventory, InventoryData coffinInventory)
+        {
+            _playerInventory = playerInventory;
+            _chestInventory = coffinInventory;
+
+            PlayerDeathEventDispatcher.OnPlayerDeath += HandleTransfer;
+        }
+
+        private void HandleTransfer()
+        {
+            if (_playerInventory.Items.Count == 0) return;
+
+            for (int i = _playerInventory.Items.Count - 1; i >= 0; i--)
+            {
+                if (_chestInventory.Items.Count >= _chestInventory.MaxSlots) break;
+
+                _chestInventory.Items.Add(_playerInventory.Items[i]);
+                _playerInventory.Items.RemoveAt(i);
+            }
+
+            UnityEngine.Debug.Log("Inventaire transféré automatiquement dans le coffre de récupération.");
+        }
+
+        public void Dispose()
+        {
+            PlayerDeathEventDispatcher.OnPlayerDeath -= HandleTransfer;
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Inventory/InventoryTransferOnDeathHandler.cs.meta
+++ b/Assets/_Core/Scripts/Inventory/InventoryTransferOnDeathHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d12ca0e8a8c33f84eaf8852ce321da67

--- a/Assets/_Core/Scripts/Players/PlayerDeathEventDispatcher.cs
+++ b/Assets/_Core/Scripts/Players/PlayerDeathEventDispatcher.cs
@@ -1,0 +1,12 @@
+namespace MoonlitMixes.Events
+{
+    public static class PlayerDeathEventDispatcher
+    {
+        public static event System.Action OnPlayerDeath;
+
+        public static void TriggerDeath()
+        {
+            OnPlayerDeath?.Invoke();
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Players/PlayerDeathEventDispatcher.cs.meta
+++ b/Assets/_Core/Scripts/Players/PlayerDeathEventDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d10b263b1f477f4dac8c5a98d39bec2


### PR DESCRIPTION
Lorsqu’un joueur meurt, tous les objets de son inventaire doivent être automatiquement transférés vers le coffre. Ces objets ne sont pas perdus et donc le joueur devra par lui suite optimiser la gestion de son coffre. Et le feedback est au début du jeu.