### PR TITLE
Repair ScriptableObjects recipe and ingredient

### DIFF
--- a/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Mush_Earth.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Ingredient/Mush_Earth.asset
@@ -16,8 +16,9 @@ MonoBehaviour:
   _elementType: 0
   _rarity: 1
   _itemUsage: 1
+  _canBeStirred: 0
   _sprite: {fileID: 1376459745, guid: 8012c03f9c9aff1428813b615afb8e96, type: 3}
-  _itemToConvert: {fileID: 11400000}
+  _itemToConvert: {fileID: 11400000, guid: cd0d1001d84c95b4ca893d98046dd9a6, type: 2}
   _description: 
   _itemPrefab: {fileID: 5960020932759483403, guid: f50e20f3f71a82745a343069ad6dcb46, type: 3}
   _state: 3

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Firebreathers_Cocktail_Recipe.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Firebreathers_Cocktail_Recipe.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6b89f3131c070c04181226af3dcc4cd0, type: 2}
   - {fileID: 11400000, guid: f661a60525fbeb64ebfcdeb9bbb655d8, type: 2}
   - {fileID: 11400000, guid: 81375a718c9a6f74fa8c500e1e18bec4, type: 2}
-  - {fileID: 11400000, guid: 5d40e064b619e05488cfad6d0b553eb5, type: 2}
+  - {fileID: 11400000, guid: 09a7d9c4b872a124db0c7703ff926aba, type: 2}
   _potionSprite: {fileID: -2001195052, guid: ead283b876b4cd44f82a97cdc09e50e4, type: 3}
   _description: Engulf the sky in the flames of hell and wield in your maw the powers
     of the dragons

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Power_Fist_Cocktail_Recipe.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Power_Fist_Cocktail_Recipe.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 12da0c7eeeebd7b4bb38dfa5cd666579, type: 2}
   - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
   - {fileID: 11400000, guid: fce321d3d37432843bf6aad0e207def7, type: 2}
-  - {fileID: 11400000, guid: 81375a718c9a6f74fa8c500e1e18bec4, type: 2}
+  - {fileID: 11400000, guid: cd0d1001d84c95b4ca893d98046dd9a6, type: 2}
   _potionSprite: {fileID: -1773807762, guid: 580d79f32dd222d4793a327273b872b4, type: 3}
   _description: "Bulks the silhouette of the user and gives the ability to carry
     mountains on a simple mortal\u2019s shoulders"

--- a/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Sonic_Speed_Elixir_Recipe.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/Final Potion/concotions/Sonic_Speed_Elixir_Recipe.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 89c60ae233e085c4192f1bea0985af64, type: 2}
   - {fileID: 11400000, guid: 2119ca4282b74b04b82c65ec0da079cb, type: 2}
   - {fileID: 11400000, guid: c269785404b090c48ad1fd1a1d9b574b, type: 2}
-  - {fileID: 11400000, guid: 5d40e064b619e05488cfad6d0b553eb5, type: 2}
+  - {fileID: 11400000, guid: 09a7d9c4b872a124db0c7703ff926aba, type: 2}
   _potionSprite: {fileID: 838779401, guid: 64629ec18a17ee846b3f152a3c3c7208, type: 3}
   _description: Vibrate through matter, transcend the limits of human speed for a
     small moment. Get from north to south in a second, pulverizing all in your path


### PR DESCRIPTION
> Il y a eux des changements sur les scriptables object pour convenir au document de recipe 

( https://docs.google.com/document/d/1IYD8EsQcP1k3TmCGsqAOh9VSPkwoiuI3dAS8vs6ntgk/edit?tab=t.0 )

> Tu trouves les recettes dans :

![image](https://github.com/user-attachments/assets/c6f224c7-fa1d-43b7-8d29-a32df5b4a38e)

> Tu trouves les ingredients dans :

![image](https://github.com/user-attachments/assets/c4f87435-08e1-4efe-82a6-837104400471)

> les modificationn des potions :

1. La recette du Firebreather's :
pas Salama_Tail mais Lava Shard

2. La recette du Power_Fist_Cocktail :
pas Mush Cuttinf Fire, il faut le Mush cutting Earth

3. La recette Sonic :
pas Salama_Tail mais Lava Shard

> Scriptable object ingredient :

1. Le mush earth devient mush earth et non le mush cutting earth