### PR TITLE
Add maximum number to take bark + small feedback

### DIFF
--- a/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
@@ -31703,10 +31703,10 @@ PrefabInstance:
       addedObject: {fileID: 907484453}
     - targetCorrespondingSourceObject: {fileID: 5357426869329275683, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 907484459}
+      addedObject: {fileID: 907484465}
     - targetCorrespondingSourceObject: {fileID: 5357426869329275683, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 907484465}
+      addedObject: {fileID: 907484471}
   m_SourcePrefab: {fileID: 100100000, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
 --- !u!1 &337228934
 GameObject:
@@ -45023,7 +45023,7 @@ Transform:
   m_GameObject: {fileID: 473214939}
   serializedVersion: 2
   m_LocalRotation: {x: 0.34570765, y: 0, z: 0, w: 0.93834233}
-  m_LocalPosition: {x: -7.95, y: 5.67, z: -40.99753}
+  m_LocalPosition: {x: -7.95, y: 5.702897, z: -40.99753}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -48469,7 +48469,7 @@ Transform:
   m_GameObject: {fileID: 511786531}
   serializedVersion: 2
   m_LocalRotation: {x: 0.34570765, y: 0, z: 0, w: 0.93834233}
-  m_LocalPosition: {x: -7.95, y: 5.67, z: -40.99753}
+  m_LocalPosition: {x: -7.95, y: 5.702897, z: -40.99753}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -91737,26 +91737,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.8464172, y: 3.9435189, z: 2.084363}
   m_Center: {x: 0.4567313, y: 1.9355003, z: 0.13796388}
---- !u!114 &907484459
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 907484440}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f71a256f3c304220b23c217824efcc9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _toolType: 1
-  _spriteArray:
-  - {fileID: 533020528, guid: 143577a218be3ab458613ce5140a0163, type: 3}
-  - {fileID: -208444210, guid: b4f7063cc8a749b4c8cba4b4fe0d003c, type: 3}
-  - {fileID: 1121773950, guid: 4558da9a291393449b9d39b0ce6512b4, type: 3}
-  - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
-  _inputCommand: 2
-  _interactionImage: {fileID: 954711614}
 --- !u!114 &907484465
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -91771,6 +91751,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _maxHits: 2
   _desativeObject: {fileID: 1459464152}
+--- !u!114 &907484471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 907484440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0feab1c9a58c4c946baba390b436184e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _toolType: 1
+  _spriteArray:
+  - {fileID: 533020528, guid: 143577a218be3ab458613ce5140a0163, type: 3}
+  - {fileID: -208444210, guid: b4f7063cc8a749b4c8cba4b4fe0d003c, type: 3}
+  - {fileID: 1121773950, guid: 4558da9a291393449b9d39b0ce6512b4, type: 3}
+  - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
+  _inputCommand: 2
+  _interactionImage: {fileID: 954711614}
 --- !u!1 &907495064
 GameObject:
   m_ObjectHideFlags: 0
@@ -170014,26 +170014,6 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.3844395, y: 3.9435189, z: 2.204029}
   m_Center: {x: 0.22574425, y: 1.93551, z: 0.07813072}
---- !u!114 &1749623583
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1749623569}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f71a256f3c304220b23c217824efcc9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _toolType: 1
-  _spriteArray:
-  - {fileID: 533020528, guid: 143577a218be3ab458613ce5140a0163, type: 3}
-  - {fileID: -208444210, guid: b4f7063cc8a749b4c8cba4b4fe0d003c, type: 3}
-  - {fileID: 1121773950, guid: 4558da9a291393449b9d39b0ce6512b4, type: 3}
-  - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
-  _inputCommand: 2
-  _interactionImage: {fileID: 1073467276}
 --- !u!114 &1749623589
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170048,6 +170028,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _maxHits: 2
   _desativeObject: {fileID: 1118858584}
+--- !u!114 &1749623595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749623569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0feab1c9a58c4c946baba390b436184e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _toolType: 1
+  _spriteArray:
+  - {fileID: 533020528, guid: 143577a218be3ab458613ce5140a0163, type: 3}
+  - {fileID: -208444210, guid: b4f7063cc8a749b4c8cba4b4fe0d003c, type: 3}
+  - {fileID: 1121773950, guid: 4558da9a291393449b9d39b0ce6512b4, type: 3}
+  - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
+  _inputCommand: 2
+  _interactionImage: {fileID: 1073467276}
 --- !u!1 &1750928331
 GameObject:
   m_ObjectHideFlags: 0
@@ -201574,10 +201574,10 @@ PrefabInstance:
       addedObject: {fileID: 1749623577}
     - targetCorrespondingSourceObject: {fileID: 7706189637624069913, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1749623583}
+      addedObject: {fileID: 1749623589}
     - targetCorrespondingSourceObject: {fileID: 7706189637624069913, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1749623589}
+      addedObject: {fileID: 1749623595}
   m_SourcePrefab: {fileID: 100100000, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
 --- !u!1 &2068354088
 GameObject:

--- a/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Forest.unity
@@ -31704,6 +31704,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 5357426869329275683, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 907484459}
+    - targetCorrespondingSourceObject: {fileID: 5357426869329275683, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 907484465}
   m_SourcePrefab: {fileID: 100100000, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
 --- !u!1 &337228934
 GameObject:
@@ -45020,7 +45023,7 @@ Transform:
   m_GameObject: {fileID: 473214939}
   serializedVersion: 2
   m_LocalRotation: {x: 0.34570765, y: 0, z: 0, w: 0.93834233}
-  m_LocalPosition: {x: -7.95, y: 5.702897, z: -40.99753}
+  m_LocalPosition: {x: -7.95, y: 5.67, z: -40.99753}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -48466,7 +48469,7 @@ Transform:
   m_GameObject: {fileID: 511786531}
   serializedVersion: 2
   m_LocalRotation: {x: 0.34570765, y: 0, z: 0, w: 0.93834233}
-  m_LocalPosition: {x: -7.95, y: 5.702897, z: -40.99753}
+  m_LocalPosition: {x: -7.95, y: 5.67, z: -40.99753}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -58755,7 +58758,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4148858655096135269, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
       propertyPath: _layerHitable.m_Bits
-      value: 0
+      value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 4150008009130701063, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
       propertyPath: m_Layer
@@ -59626,6 +59629,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 5156862080266331500}
     - target: {fileID: 8171506437572305494, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
+      propertyPath: m_ActionEvents.Array.data[1].m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6682728786630397090}
+    - target: {fileID: 8171506437572305494, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
       propertyPath: m_ActionEvents.Array.data[2].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 859754507}
@@ -59764,6 +59771,10 @@ PrefabInstance:
     - target: {fileID: 8171506437572305494, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
       propertyPath: m_ActionEvents.Array.data[28].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: SendBool
+      objectReference: {fileID: 0}
+    - target: {fileID: 8171506437572305494, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
+      propertyPath: m_ActionEvents.Array.data[1].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UseTools, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 8171506437572305494, guid: aa5b3dd980f340345ac95ff423cc4e6a, type: 3}
       propertyPath: m_ActionEvents.Array.data[4].m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -91746,6 +91757,20 @@ MonoBehaviour:
   - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
   _inputCommand: 2
   _interactionImage: {fileID: 954711614}
+--- !u!114 &907484465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 907484440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a77d0e4eac1544f4bbb469ba26c4219e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxHits: 2
+  _desativeObject: {fileID: 1459464152}
 --- !u!1 &907495064
 GameObject:
   m_ObjectHideFlags: 0
@@ -109281,6 +109306,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 742752074}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1118858584 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5146345230909592548, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
+  m_PrefabInstance: {fileID: 2067362027}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1119930408
 GameObject:
   m_ObjectHideFlags: 0
@@ -141990,6 +142020,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 742752074}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1459464152 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7477092793161451486, guid: 582989ce64eaa3e4ea9ae644d97d1d0f, type: 3}
+  m_PrefabInstance: {fileID: 335917438}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1461028195
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -169999,6 +170034,20 @@ MonoBehaviour:
   - {fileID: -1154067679, guid: b4e00863d0168d94d8aa1b265a008391, type: 3}
   _inputCommand: 2
   _interactionImage: {fileID: 1073467276}
+--- !u!114 &1749623589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749623569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a77d0e4eac1544f4bbb469ba26c4219e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxHits: 2
+  _desativeObject: {fileID: 1118858584}
 --- !u!1 &1750928331
 GameObject:
   m_ObjectHideFlags: 0
@@ -201526,6 +201575,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7706189637624069913, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1749623583}
+    - targetCorrespondingSourceObject: {fileID: 7706189637624069913, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1749623589}
   m_SourcePrefab: {fileID: 100100000, guid: 91df33e5e6fd72c4b80e40b934b4f69d, type: 3}
 --- !u!1 &2068354088
 GameObject:

--- a/Assets/_Core/Scripts/Health/TreeHealth.cs
+++ b/Assets/_Core/Scripts/Health/TreeHealth.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace MoonlitMixes.ExplorationTools
+{
+    public class TreeHealth : MonoBehaviour
+    {
+        [Header("Number of times the bark can be recovered")]
+        [SerializeField] private int _maxHits = 2;
+        private int _currentHits = 0;
+
+        [Header("Object to deactivate when the tree is cut")]
+        [SerializeField] private GameObject _desativeObject;
+
+        public bool CanChop()
+        {
+            return _currentHits < _maxHits;
+        }
+
+        public void Chop()
+        {
+            if (CanChop())
+            {
+                _currentHits++;
+
+                if (_currentHits >= _maxHits)
+                {
+                    if (_desativeObject != null)
+                    {
+                        _desativeObject.SetActive(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Health/TreeHealth.cs.meta
+++ b/Assets/_Core/Scripts/Health/TreeHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a77d0e4eac1544f4bbb469ba26c4219e

--- a/Assets/_Core/Scripts/Interaction/TreeInteractionObject.cs
+++ b/Assets/_Core/Scripts/Interaction/TreeInteractionObject.cs
@@ -1,0 +1,37 @@
+using MoonlitMixes.ExplorationTools;
+
+namespace MoonlitMixes.Interactions
+{
+    public class TreeInteractionObject : InteractionObject
+    {
+        private bool _uiEnabledLastFrame = false;
+
+        private void Update()
+        {
+            TreeHealth treeHealth = GetComponent<TreeHealth>();
+
+            if (_uiEnabledLastFrame && treeHealth != null && !treeHealth.CanChop())
+            {
+                DisableUI();
+                _uiEnabledLastFrame = false;
+            }
+        }
+
+        public override void EnableUI()
+        {
+            TreeHealth treeHealth = GetComponent<TreeHealth>();
+
+            if (treeHealth == null || treeHealth.CanChop())
+            {
+                base.EnableUI();
+                _uiEnabledLastFrame = true;
+            }
+        }
+
+        public override void DisableUI()
+        {
+            base.DisableUI();
+            _uiEnabledLastFrame = false;
+        }
+    }
+}

--- a/Assets/_Core/Scripts/Interaction/TreeInteractionObject.cs.meta
+++ b/Assets/_Core/Scripts/Interaction/TreeInteractionObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0feab1c9a58c4c946baba390b436184e

--- a/Assets/_Core/Scripts/ScriptableObjects/InventoriesTest/Inventory Player.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/InventoriesTest/Inventory Player.asset
@@ -13,5 +13,9 @@ MonoBehaviour:
   m_Name: Inventory Player
   m_EditorClassIdentifier: 
   _inventoryMode: 0
-  _items: []
+  _items:
+  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
+  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
+  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
+  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
   _maxSlots: 15

--- a/Assets/_Core/Scripts/ScriptableObjects/InventoriesTest/Inventory Player.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/InventoriesTest/Inventory Player.asset
@@ -13,9 +13,5 @@ MonoBehaviour:
   m_Name: Inventory Player
   m_EditorClassIdentifier: 
   _inventoryMode: 0
-  _items:
-  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
-  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
-  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
-  - {fileID: 11400000, guid: 584889c56fc00b2498c09e0698c6ef88, type: 2}
+  _items: []
   _maxSlots: 15

--- a/Assets/_Core/Scripts/Tools/UseTools.cs
+++ b/Assets/_Core/Scripts/Tools/UseTools.cs
@@ -77,13 +77,29 @@ public class UseTools : MonoBehaviour
 
     private void UseMachete()
     {
-        RaycastHit hit;
-        if (Physics.Raycast(transform.position + _raycastOffset, transform.forward, out hit, 2f, _layerHitable))
+        if (Physics.Raycast(transform.position + _raycastOffset, transform.forward, out RaycastHit hit, 2f, _layerHitable))
         {
-            ItemListData itemList = hit.collider.GetComponent<ItemListSource>()?.GetItemList();
+            var itemSource = hit.collider.GetComponent<ItemListSource>();
+            var itemList = itemSource?.GetItemList();
 
             if (itemList != null && itemList.ToolType == ToolType.Machete)
             {
+                TreeHealth treeHealth = hit.collider.GetComponent<TreeHealth>();
+
+                if (treeHealth == null)
+                {
+                    Debug.LogWarning("Aucun TreeHealth trouvé sur cet objet.");
+                    return;
+                }
+
+                if (!treeHealth.CanChop())
+                {
+                    Debug.Log("Cet arbre a déjà été coupé deux fois.");
+                    return;
+                }
+
+                treeHealth.Chop();
+
                 if (itemList.Items.Count > 0)
                 {
                     ItemData itemToAdd = itemList.Items[0];
@@ -97,7 +113,6 @@ public class UseTools : MonoBehaviour
             }
         }
     }
-
 
     private void UsePickaxe()
     {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Register
+  - Chest
   layers:
   - Default
   - TransparentFX
@@ -18,7 +19,7 @@ TagManager:
   - Inventory
   - Player
   - DoorScenes
-  - 
+  - Interactable Object
   - 
   - 
   - 


### PR DESCRIPTION
### 2 barks / par arbres

- Ajout du script TreeHealth pour suivre l'état de coupe des arbres.
- Chaque arbre ne peut désormais être coupé que 2 fois maximum.
- L'appel à UseMachete() vérifie via TreeHealth.CanChop() si l’arbre peut encore être coupé, et incrémente les utilisations.
- Désactivation de GameObject `Firefly` à la fin de la vie de l’arbre pour un effet de feedback.

Si un arbre atteint la limite de coupe (2 utilisations), son `Firefly` est désactivé.