### PR TITLE
Dev progess/win condition

### DIFF
--- a/Assets/_Core/Scenes/ScenesFinales/S_Shop_Twilight.unity
+++ b/Assets/_Core/Scenes/ScenesFinales/S_Shop_Twilight.unity
@@ -3345,6 +3345,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   totalPriceText: {fileID: 821399426}
+  _isLoanRefunded: 0
+  _loanPrice: 600
+  _day1NeededMoney: 120
+  _day2NeededMoney: 220
+  _day3NeededMoney: 415
 --- !u!1 &367902605
 GameObject:
   m_ObjectHideFlags: 0
@@ -6639,7 +6644,8 @@ MonoBehaviour:
   _timeBetweenSpawns: 2
   _maxCustomers: 3
   _playerMovement: {fileID: 7855766532908294441}
-  _dayNightCycleInfo: {fileID: 0}
+  _dayNightCycleInfo: {fileID: 11400000, guid: 51f631fcb88537044928d007237a09a5, type: 2}
+  _endGameDialogue: {fileID: 1874206143}
 --- !u!4 &814347454
 Transform:
   m_ObjectHideFlags: 0
@@ -16128,6 +16134,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1874206141}
   - component: {fileID: 1874206142}
+  - component: {fileID: 1874206143}
   m_Layer: 5
   m_Name: DialogueManager
   m_TagString: Untagged
@@ -16180,6 +16187,27 @@ MonoBehaviour:
   _spriteSpeakerEffects:
   - {fileID: 309927957}
   - {fileID: 1462320358}
+  _gameObjectA: {fileID: 897944185}
+  _gameObjectB: {fileID: 1334013626}
+--- !u!114 &1874206143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1874206140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c45e6674dfe147845a5c4ec8197c7672, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _potionPriceCalculate: {fileID: 354707295}
+  _dailyLoseDialogue: {fileID: 11400000, guid: e9f9838b245a2944aa8fa650c5aa0e79, type: 2}
+  _dailyWinDialogue: {fileID: 11400000, guid: ff85d14141c6eca49b62fcb94b996265, type: 2}
+  _loseDialogue: {fileID: 11400000, guid: 6880fddfd6bdf014198841ee022b0d47, type: 2}
+  _winDialogue: {fileID: 11400000, guid: caad1677367ea4a468c830bad9af6b46, type: 2}
+  _endImage: {fileID: 0}
+  _dayNightCycleInfo: {fileID: 11400000, guid: 51f631fcb88537044928d007237a09a5, type: 2}
 --- !u!1 &1876273383
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Core/Scripts/Dialogue/DialogueController.cs
+++ b/Assets/_Core/Scripts/Dialogue/DialogueController.cs
@@ -34,9 +34,13 @@ namespace MoonlitMixes.Dialogue
         private bool _isSkipText = false;
         private bool _isEffectRunning = false;
         private bool _hasSkippedEffect = false;
+        private bool _isLastDialogue = false;
+        public bool IsLastDialogue { set { _isLastDialogue = value; } }
 
         private PlayerInput _playerInput;
         private InputActionAsset _inputActionAsset;
+        private InputActionMap _originalActionMap;
+        private EndGameDialogue _endGameDialogue;
 
         private void Awake()
         {
@@ -48,6 +52,7 @@ namespace MoonlitMixes.Dialogue
             _instance = this;
 
             _playerInput = FindFirstObjectByType<PlayerInput>();
+            _endGameDialogue = gameObject.GetComponent<EndGameDialogue>();
             _inputActionAsset = _playerInput?.actions;
 
             if (_playerInput == null || _inputActionAsset == null)
@@ -268,6 +273,7 @@ namespace MoonlitMixes.Dialogue
 
             OnDialogueFinished?.Invoke();
             OnDialogueClosed?.Invoke();
+            if (_isLastDialogue) _endGameDialogue.EndGame();
         }
 
         public void OnNextDialoguePressed(InputAction.CallbackContext ctx)

--- a/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs
+++ b/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs
@@ -1,0 +1,34 @@
+using MoonlitMixes.Datas;
+using UnityEngine;
+
+namespace MoonlitMixes.Dialogue
+{
+
+    public class EndGameDialogue : MonoBehaviour
+    {
+        [SerializeField] private Potion.PotionPriceCalculate _potionPriceCalculate;
+        [SerializeField] private DialogueData _loseDialogue;
+        [SerializeField] private DialogueData _winDialogue;
+        private DialogueController _dialogueController;
+
+        private void Start()
+        {
+            _dialogueController = gameObject.GetComponent<DialogueController>();
+        }
+
+        public void EndGame()
+        {
+            if (_potionPriceCalculate.IsLoanRefunded) //Win dialogue
+            {
+                _dialogueController.StartDialogue(_winDialogue);
+            }
+            else //lose dialogue
+            {
+                _dialogueController.StartDialogue(_loseDialogue);
+
+            }
+        }
+    }
+
+}
+

--- a/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs
+++ b/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs
@@ -1,4 +1,6 @@
 using MoonlitMixes.Datas;
+using NaughtyAttributes;
+using System.Collections;
 using UnityEngine;
 
 namespace MoonlitMixes.Dialogue
@@ -7,28 +9,49 @@ namespace MoonlitMixes.Dialogue
     public class EndGameDialogue : MonoBehaviour
     {
         [SerializeField] private Potion.PotionPriceCalculate _potionPriceCalculate;
+        [SerializeField] private DialogueData _dailyLoseDialogue;
+        [SerializeField] private DialogueData _dailyWinDialogue;
         [SerializeField] private DialogueData _loseDialogue;
         [SerializeField] private DialogueData _winDialogue;
+        [SerializeField] private GameObject _endImage;
+        [SerializeField] private DayNightCycleInfo _dayNightCycleInfo;
         private DialogueController _dialogueController;
 
         private void Start()
         {
             _dialogueController = gameObject.GetComponent<DialogueController>();
         }
-
-        public void EndGame()
+        [Button]
+        public void EndDayDialogue()
         {
-            if (_potionPriceCalculate.IsLoanRefunded) //Win dialogue
+            switch (_dayNightCycleInfo.ActualDay)
             {
-                _dialogueController.StartDialogue(_winDialogue);
-            }
-            else //lose dialogue
-            {
-                _dialogueController.StartDialogue(_loseDialogue);
-
+                case 0:
+                    if(_potionPriceCalculate.Day1Money>=_potionPriceCalculate.Day1NeededMoney) _dialogueController.StartDialogue(_dailyWinDialogue);
+                    else _dialogueController.StartDialogue(_dailyLoseDialogue);
+                    break;
+                case 1:
+                    if (_potionPriceCalculate.Day2Money >= _potionPriceCalculate.Day2NeededMoney) _dialogueController.StartDialogue(_dailyWinDialogue);
+                    else _dialogueController.StartDialogue(_dailyLoseDialogue);
+                    break;
+                case 2:
+                    _dialogueController.IsLastDialogue = true;
+                    if (_potionPriceCalculate.IsLoanRefunded) _dialogueController.StartDialogue(_winDialogue);
+                    else _dialogueController.StartDialogue(_loseDialogue);
+                    break;
+                default:
+                    Debug.LogWarning("Mauvaise valeure de jour envoyé");
+                    break;
             }
         }
+        public void EndGame()
+        {
+            if(_endImage != null) _endImage.SetActive(true);
+        }
+        public IEnumerator DelayGame() 
+        { 
+            yield return new WaitForSeconds(5);
+        }
     }
-
 }
 

--- a/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs.meta
+++ b/Assets/_Core/Scripts/Dialogue/EndGameDialogue.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c45e6674dfe147845a5c4ec8197c7672

--- a/Assets/_Core/Scripts/PNJ/CustomerSpawner.cs
+++ b/Assets/_Core/Scripts/PNJ/CustomerSpawner.cs
@@ -1,6 +1,7 @@
 using MoonlitMixes.AI.PNJ.StateMachine;
 using MoonlitMixes.AI.PNJ.StateMachine.States;
 using MoonlitMixes.Datas;
+using MoonlitMixes.Dialogue;
 using MoonlitMixes.Player;
 using System;
 using System.Collections.Generic;
@@ -19,6 +20,7 @@ namespace MoonlitMixes.AI.PNJ.Spawner
         [SerializeField] private int _maxCustomers = 3;
         [SerializeField] private PlayerMovement _playerMovement;
         [SerializeField] private DayNightCycleInfo _dayNightCycleInfo;
+        [SerializeField] private EndGameDialogue _endGameDialogue;
 
         private int _currentPNJIndex = 0;
         private bool _isSpawning = false;
@@ -102,6 +104,7 @@ namespace MoonlitMixes.AI.PNJ.Spawner
             _dayNightCycleInfo.ActualTimePhase++;
             _playerMovement.BlockMovement(false);
             _isSpawning = false;
+            _endGameDialogue.EndDayDialogue();
         }
     }
 }

--- a/Assets/_Core/Scripts/Potion/PotionPriceCalculate.cs
+++ b/Assets/_Core/Scripts/Potion/PotionPriceCalculate.cs
@@ -8,10 +8,23 @@ namespace MoonlitMixes.Potion
         public int SelectedPotionPrice { get; private set; }
 
         [SerializeField] private TextMeshProUGUI totalPriceText;
-        private int totalPotionPrice = 0;
-        private bool _isLoanRefunded = false;
-        [SerializeField] private int _loanPrice;
-        public bool IsLoanRefunded { get { return _isLoanRefunded; } }
+        [SerializeField] private int totalPotionPrice = 0;
+        [SerializeField] private bool _isLoanRefunded = false;
+        [SerializeField] private int _loanPrice = 600;
+        [SerializeField] private int _day1NeededMoney = 120;
+        [SerializeField] private int _day2NeededMoney = 220;
+        [SerializeField] private int _day3NeededMoney = 415;
+        private int _day1Money;
+        private int _day2Money;
+        private int _day3Money;
+
+        public int Day1NeededMoney => _day1NeededMoney;
+        public int Day2NeededMoney => _day2NeededMoney;
+        public int Day3NeededMoney => _day3NeededMoney;
+        public int Day1Money => _day1Money;
+        public int Day2Money => _day2Money;
+        public int Day3Money => _day3Money;
+        public bool IsLoanRefunded =>_isLoanRefunded;
 
         public void SetSelectedPotionPrice(int price)
         {
@@ -41,14 +54,32 @@ namespace MoonlitMixes.Potion
             _isLoanRefunded = VerficationLoan();
         }
 
+        
+        private void CalculateDailyMoney(int day)
+        {
+            switch (day)
+            {
+                case 1:
+                    _day1Money = totalPotionPrice;
+                    break;
+                case 2:
+                    _day2Money = totalPotionPrice- _day1Money;
+                    break;
+                case 3:
+                    _day3Money = totalPotionPrice - (_day1Money+_day2Money);
+                    break;
+                default:
+                    Debug.LogWarning("Mauvaise valeure de jour envoyé");
+                    break; 
+            }
+        }
         private void UpdateTotalPriceUI()
         {
             if (totalPriceText != null)
             {
-                totalPriceText.text = $"Total: {totalPotionPrice}";
+                totalPriceText.text = $"Total: {totalPotionPrice} / {_loanPrice}";
             }
         }
-
         private float GetMultiplier(int failedAttempts)
         {
             return failedAttempts switch

--- a/Assets/_Core/Scripts/Potion/PotionPriceCalculate.cs
+++ b/Assets/_Core/Scripts/Potion/PotionPriceCalculate.cs
@@ -9,6 +9,9 @@ namespace MoonlitMixes.Potion
 
         [SerializeField] private TextMeshProUGUI totalPriceText;
         private int totalPotionPrice = 0;
+        private bool _isLoanRefunded = false;
+        [SerializeField] private int _loanPrice;
+        public bool IsLoanRefunded { get { return _isLoanRefunded; } }
 
         public void SetSelectedPotionPrice(int price)
         {
@@ -35,6 +38,7 @@ namespace MoonlitMixes.Potion
 
             // Toujours mettre à jour l'UI, même si basePrice est 0
             UpdateTotalPriceUI();
+            _isLoanRefunded = VerficationLoan();
         }
 
         private void UpdateTotalPriceUI()
@@ -54,6 +58,11 @@ namespace MoonlitMixes.Potion
                 2 => 0.25f,
                 _ => 0f
             };
+        }
+        private bool VerficationLoan()
+        {
+            if (totalPotionPrice>_loanPrice) return true;
+            else return false;
         }
     }
 }

--- a/Assets/_Core/Scripts/ScriptableObjects/PNJDialogue/Cinematic/EndCinematicBad/BadEndCinematic1.asset
+++ b/Assets/_Core/Scripts/ScriptableObjects/PNJDialogue/Cinematic/EndCinematicBad/BadEndCinematic1.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _text: '*Crow looks to the door of the shop, remarking the blood and claw marks.*'
   _speakerIndex: 1
-  _speakerSprite: {fileID: 21300000, guid: 6dc033d7d915f904fa7269ef85c94224, type: 3}
+  _speakerSprite: {fileID: -933607939, guid: b6cc13084ac786043905e89a34e22b3c, type: 3}
   _effect: 0
   _trembleIntensityX: 5
   _trembleIntensityY: 5


### PR DESCRIPTION
Ajout des dialogues de fin de jour
Ajout des dialogues de fin de jeu
Ajout du crédit et calcul du crédit

Explication : A la fin de chaque journée, âpres que le dernier client soit partit, le corbeau a un dialogue avec le loup, pour lui dire si il est en retard sur le crédits ou pas
Si le loup a vendu correctement toutes ses potions, il sera dans les temps, sinon le corbeau lui dira qu'il est en retard 

Mais au jour 3, a la place de ce dialogue, la cinématique de fin se lance, en fonction de si on a assez d'argent ou pas

Bug actuel -> le sprite du loup est trop petit suivant les dialogue --> mathys corrigera ça dans une autre branche

Comment tester : 

Aller dans la scene shop nuit, Dans l'objet dialogue manager, il y un bouton pour lancer les dialogues, Dans les scriptable object DayandNightInfo, on peut changer le jour ( de  0 a 2), et dans le canvas money, il y a le script PotionPrice Calculate ou on peut cocher une case pour savoir si oui ou non on a assez d'argent pour rembourser le crédit